### PR TITLE
Create .vscodeignore #103

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,0 +1,4 @@
+.vscode/**
+**/*.rb
+**/*.yaml
+.gitignore


### PR DESCRIPTION
Per #103, and https://code.visualstudio.com/api/working-with-extensions/bundling-extension#publishing
`.vscodeignore` should be updated to exclude `.vscode` and source files.