### PR TITLE
Allow textmate_tools to resolve arrays of includes #116

### DIFF
--- a/debug.yaml
+++ b/debug.yaml
@@ -15,3 +15,12 @@
   literal_numeric_seperator:
     :match: "(?<!')'(?!')"
     :name: punctuation.separator.constant.numeric.cpp
+  test_include_array:
+    :begin: foo
+    :end: bar
+    :patterns:
+    - :include: "#1"
+    - :include: "#2"
+    - :include: "#3"
+    - :include: "#4"
+    - :include: "$base"

--- a/textmate_tools.rb
+++ b/textmate_tools.rb
@@ -103,7 +103,7 @@ class Grammar
         if (repository.is_a? Hash) && (repository != {})
             textmate_repository = {}
             for each_key, each_value in repository.each_pair
-                textmate_repository[each_key.to_s] = Grammar.toTag(each_value)
+                textmate_repository[each_key.to_s] = Grammar.toTag(each_value)[0]
             end
             return textmate_repository
         end

--- a/textmate_tools.rb
+++ b/textmate_tools.rb
@@ -177,10 +177,7 @@ class Grammar
             raise "\n\nWhen calling convertIncludesToPatternList() the argument wasn't an array\nThe argument is:#{includes}"
         end
         # create the pattern list
-        patterns = []
-        for each_include in includes
-            patterns.concat(Grammar.toTag(each_include))
-        end
+        patterns = Grammar.toTag(includes)
         return patterns
     end
     

--- a/textmate_tools.rb
+++ b/textmate_tools.rb
@@ -77,18 +77,25 @@ class Grammar
     end
     
     def self.toTag(data)
+        # if its an array then convert each element to its tag
+        if (data.instance_of? Array)
+            tags = []
+            for each_data in data
+                tags.concat(Grammar.toTag(each_data))
+            end
+            return tags
         # if its a string then include it directly
-        if (data.instance_of? String)
-            return { include: data }
+        elsif (data.instance_of? String)
+            return [{ include: data }]
         # if its a symbol then include a # to make it a repository_name reference
         elsif (data.instance_of? Symbol)
-            return { include: "##{data}" }
+            return [{ include: "##{data}" }]
         # if its a pattern, then convert it to a tag
         elsif (data.instance_of? Regexp) or (data.instance_of? Range)
-            return data.to_tag
+            return [data.to_tag]
         # if its a hash, then just add it as-is
         elsif (data.instance_of? Hash)
-            return data
+            return [data]
         end
     end
     
@@ -172,7 +179,7 @@ class Grammar
         # create the pattern list
         patterns = []
         for each_include in includes
-            patterns.push(Grammar.toTag(each_include))
+            patterns.concat(Grammar.toTag(each_include))
         end
         return patterns
     end

--- a/textmate_tools_debugging.rb
+++ b/textmate_tools_debugging.rb
@@ -28,6 +28,26 @@ number_seperator_pattern = newPattern(
     tag_as:"punctuation.separator.constant.numeric"
     )
 
+test_deeply_nested = [
+    "#3",
+    "#4",
+]
+test_include_array = [
+    "#1",
+    "#2",
+    test_deeply_nested,
+]
+
+Range.new(
+    repository_name: 'test_include_array',
+    start_pattern: /foo/,
+    end_pattern: /bar/,
+    includes: [
+        test_include_array,
+        "$base"
+    ]
+)
+
 cpp_grammar.initalContextIncludes(
     newPattern(
         should_fully_match: [ "baz baz", "quix quix" ],


### PR DESCRIPTION
This PR modifies `Grammar::toTag` to return an array. This allows `::toTag` to turn nested arrays of taggable objects into a flat array of tags. 

Example ruby fragment
```ruby
test_deeply_nested = [
    "#3",
    "#4",
]
test_include_array = [
    "#1",
    "#2",
    test_deeply_nested,
]

Range.new(
    repository_name: 'test_include_array',
    start_pattern: /foo/,
    end_pattern: /bar/,
    includes: [
        test_include_array,
        "$base"
    ]
)
```

resultant grammar fragment
```yaml
  test_include_array:
    :begin: foo
    :end: bar
    :patterns:
    - :include: "#1"
    - :include: "#2"
    - :include: "#3"
    - :include: "#4"
    - :include: "$base"
```