### PR TITLE
make functions support universal character sets #17

### DIFF
--- a/cpp/generate.rb
+++ b/cpp/generate.rb
@@ -3007,32 +3007,29 @@ cpp_grammar[:qualified_type] = qualified_type = newPattern(
             :storage_types,
             :operators,
             :vararg_ellipses,
-            {
-                name: "meta.function.definition.parameters",
-                begin: "(?x)\n(?!(?:while|for|do|if|else|switch|catch|return|typeid|alignof|alignas|sizeof|and|and_eq|bitand|bitor|compl|not|not_eq|or|or_eq|typeid|xor|xor_eq|alignof|alignas)\\s*\\()\n(\n(?:[A-Za-z_][A-Za-z0-9_]*+|::)++ # actual name\n|\n(?:(?<=operator)(?:[-*&<>=+!]+|\\(\\)|\\[\\]))\n)\n\\s*(\\()",
-                beginCaptures: {
-                    "1" => {
-                        name: "entity.name.function"
-                    },
-                    "2" => {
-                        name: "punctuation.section.parameters.begin.bracket.round"
-                    },
-                },
-                end: /\)|:/,
-                endCaptures: {
-                    "0" => {
-                        name: "punctuation.section.parameters.end.bracket.round"
-                    }
-                },
-                patterns: [
-                    {
-                        include: "#probably_a_parameter"
-                    },
-                    {
-                        include: "#function_context_c"
-                    }
-                ]
-            },
+            PatternRange.new(
+                tag_as: "meta.function.definition.parameters",
+                # this pattern was posessive but that depends on https://github.com/jeff-hykin/cpp-textmate-grammar/issues/127
+                # integration testing says we are fin however
+                start_pattern: lookAheadToAvoid(newPattern(@cpp_tokens.that(:isOperator).or(@cpp_tokens.that(:isControlFlow))).maybe(@spaces).then(/\(/))
+                    .then(
+                        match: oneOrMoreOf(identifier.or(/::/)).or(lookBehindFor(/operator/).then(@cpp_tokens.that(:canAppearAfterOperatorKeyword))),
+                        tag_as: "entity.name.function"
+                    ).maybe(@spaces)
+                    .then(
+                        match: /\(/,
+                        tag_as: "punctuation.section.parameters.begin.bracket.round"
+                    ),
+                # no idea why this matches :
+                end_pattern: newPattern(
+                    match: /\)|:/,
+                    tag_as: "punctuation.section.parameters.end.bracket.round"
+                ),
+                includes: [
+                    :probably_a_parameter,
+                    :function_context_c,
+                ],
+            ),
             {
                 begin: "\\(",
                 beginCaptures: {

--- a/cpp/generate.rb
+++ b/cpp/generate.rb
@@ -698,6 +698,29 @@ cpp_grammar[:qualified_type] = qualified_type = newPattern(
             ),
         includes: [ :function_call_context_c ]
         )
+    cpp_grammar[:legacy_function_definition] = PatternRange.new(
+            tag_as: "meta.function.definition.parameters",
+            # this pattern was posessive but that depends on https://github.com/jeff-hykin/cpp-textmate-grammar/issues/127
+            # integration testing says we are fin however
+            start_pattern: lookAheadToAvoid(newPattern(@cpp_tokens.that(:isOperator).or(@cpp_tokens.that(:isControlFlow))).maybe(@spaces).then(/\(/))
+                .then(
+                    match: oneOrMoreOf(identifier.or(/::/)).or(lookBehindFor(/operator/).then(@cpp_tokens.that(:canAppearAfterOperatorKeyword))),
+                    tag_as: "entity.name.function"
+                ).maybe(@spaces)
+                .then(
+                    match: /\(/,
+                    tag_as: "punctuation.section.parameters.begin.bracket.round"
+                ),
+            # no idea why this matches :
+            end_pattern: newPattern(
+                match: /\)|:/,
+                tag_as: "punctuation.section.parameters.end.bracket.round"
+            ),
+            includes: [
+                :probably_a_parameter,
+                :function_context_c,
+            ],
+        )
 #
 # Operators
 #
@@ -3007,29 +3030,7 @@ cpp_grammar[:qualified_type] = qualified_type = newPattern(
             :storage_types,
             :operators,
             :vararg_ellipses,
-            PatternRange.new(
-                tag_as: "meta.function.definition.parameters",
-                # this pattern was posessive but that depends on https://github.com/jeff-hykin/cpp-textmate-grammar/issues/127
-                # integration testing says we are fin however
-                start_pattern: lookAheadToAvoid(newPattern(@cpp_tokens.that(:isOperator).or(@cpp_tokens.that(:isControlFlow))).maybe(@spaces).then(/\(/))
-                    .then(
-                        match: oneOrMoreOf(identifier.or(/::/)).or(lookBehindFor(/operator/).then(@cpp_tokens.that(:canAppearAfterOperatorKeyword))),
-                        tag_as: "entity.name.function"
-                    ).maybe(@spaces)
-                    .then(
-                        match: /\(/,
-                        tag_as: "punctuation.section.parameters.begin.bracket.round"
-                    ),
-                # no idea why this matches :
-                end_pattern: newPattern(
-                    match: /\)|:/,
-                    tag_as: "punctuation.section.parameters.end.bracket.round"
-                ),
-                includes: [
-                    :probably_a_parameter,
-                    :function_context_c,
-                ],
-            ),
+            :legacy_function_definition,
             {
                 begin: "\\(",
                 beginCaptures: {

--- a/syntaxes/cpp.tmLanguage.json
+++ b/syntaxes/cpp.tmLanguage.json
@@ -1245,6 +1245,32 @@
         }
       ]
     },
+    "legacy_function_definition": {
+      "name": "meta.function.definition.parameters.cpp",
+      "begin": "(?!(?:(?:::|\\+\\+|\\-\\-|\\(\\)|\\[\\]|\\.|\\->|\\+\\+|\\-\\-|\\+|\\-|!|not|~|compl|\\*|&|sizeof|sizeof\\.\\.\\.|new|new\\[\\]|delete|delete\\[\\]|\\.\\*|\\->\\*|\\*|\\/|%|\\+|\\-|<<|>>|<=>|<|<=|>|>=|==|!=|not_eq|&|bitand|\\^|xor|\\||bitor|&&|and|\\|\\||or|\\?:|throw|=|\\+=|\\-=|\\*=|\\/=|%=|<<=|>>=|&=|and_eq|\\^=|xor_eq|\\|=|or_eq|,|alignof|alignas|typeid|noexcept|static_cast|dynamic_cast|const_cast|reinterpret_cast)|(?:throw|while|for|do|if|else|goto|switch|try|catch|return|break|case|continue|default))\\s*\\()((?:(?:(?:(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F]))(?:(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F])))*|::))+|(?<=operator)(?:\\+\\+|\\-\\-|\\(\\)|\\[\\]|\\->|\\+\\+|\\-\\-|\\+|\\-|!|~|\\*|&|new|new\\[\\]|delete|delete\\[\\]|\\->\\*|\\*|\\/|%|\\+|\\-|<<|>>|<=>|<|<=|>|>=|==|!=|&|\\^|\\||&&|\\|\\||=|\\+=|\\-=|\\*=|\\/=|%=|<<=|>>=|&=|\\^=|\\|=|,)))\\s*(\\()",
+      "beginCaptures": {
+        "1": {
+          "name": "entity.name.function.cpp"
+        },
+        "2": {
+          "name": "punctuation.section.parameters.begin.bracket.round.cpp"
+        }
+      },
+      "end": "(\\)|:)",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.section.parameters.end.bracket.round.cpp"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#probably_a_parameter"
+        },
+        {
+          "include": "#function_context_c"
+        }
+      ]
+    },
     "operators": {
       "patterns": [
         {
@@ -4211,30 +4237,7 @@
           "include": "#vararg_ellipses"
         },
         {
-          "name": "meta.function.definition.parameters.cpp",
-          "begin": "(?!(?:(?:::|\\+\\+|\\-\\-|\\(\\)|\\[\\]|\\.|\\->|\\+\\+|\\-\\-|\\+|\\-|!|not|~|compl|\\*|&|sizeof|sizeof\\.\\.\\.|new|new\\[\\]|delete|delete\\[\\]|\\.\\*|\\->\\*|\\*|\\/|%|\\+|\\-|<<|>>|<=>|<|<=|>|>=|==|!=|not_eq|&|bitand|\\^|xor|\\||bitor|&&|and|\\|\\||or|\\?:|throw|=|\\+=|\\-=|\\*=|\\/=|%=|<<=|>>=|&=|and_eq|\\^=|xor_eq|\\|=|or_eq|,|alignof|alignas|typeid|noexcept|static_cast|dynamic_cast|const_cast|reinterpret_cast)|(?:throw|while|for|do|if|else|goto|switch|try|catch|return|break|case|continue|default))\\s*\\()((?:(?:(?:(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F]))(?:(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F])))*|::))+|(?<=operator)(?:\\+\\+|\\-\\-|\\(\\)|\\[\\]|\\->|\\+\\+|\\-\\-|\\+|\\-|!|~|\\*|&|new|new\\[\\]|delete|delete\\[\\]|\\->\\*|\\*|\\/|%|\\+|\\-|<<|>>|<=>|<|<=|>|>=|==|!=|&|\\^|\\||&&|\\|\\||=|\\+=|\\-=|\\*=|\\/=|%=|<<=|>>=|&=|\\^=|\\|=|,)))\\s*(\\()",
-          "beginCaptures": {
-            "1": {
-              "name": "entity.name.function.cpp"
-            },
-            "2": {
-              "name": "punctuation.section.parameters.begin.bracket.round.cpp"
-            }
-          },
-          "end": "(\\)|:)",
-          "endCaptures": {
-            "1": {
-              "name": "punctuation.section.parameters.end.bracket.round.cpp"
-            }
-          },
-          "patterns": [
-            {
-              "include": "#probably_a_parameter"
-            },
-            {
-              "include": "#function_context_c"
-            }
-          ]
+          "include": "#legacy_function_definition"
         },
         {
           "begin": "\\(",

--- a/syntaxes/cpp.tmLanguage.json
+++ b/syntaxes/cpp.tmLanguage.json
@@ -4212,7 +4212,7 @@
         },
         {
           "name": "meta.function.definition.parameters.cpp",
-          "begin": "(?x)\n(?!(?:while|for|do|if|else|switch|catch|return|typeid|alignof|alignas|sizeof|and|and_eq|bitand|bitor|compl|not|not_eq|or|or_eq|typeid|xor|xor_eq|alignof|alignas)\\s*\\()\n(\n(?:[A-Za-z_][A-Za-z0-9_]*+|::)++ # actual name\n|\n(?:(?<=operator)(?:[-*&<>=+!]+|\\(\\)|\\[\\]))\n)\n\\s*(\\()",
+          "begin": "(?!(?:(?:::|\\+\\+|\\-\\-|\\(\\)|\\[\\]|\\.|\\->|\\+\\+|\\-\\-|\\+|\\-|!|not|~|compl|\\*|&|sizeof|sizeof\\.\\.\\.|new|new\\[\\]|delete|delete\\[\\]|\\.\\*|\\->\\*|\\*|\\/|%|\\+|\\-|<<|>>|<=>|<|<=|>|>=|==|!=|not_eq|&|bitand|\\^|xor|\\||bitor|&&|and|\\|\\||or|\\?:|throw|=|\\+=|\\-=|\\*=|\\/=|%=|<<=|>>=|&=|and_eq|\\^=|xor_eq|\\|=|or_eq|,|alignof|alignas|typeid|noexcept|static_cast|dynamic_cast|const_cast|reinterpret_cast)|(?:throw|while|for|do|if|else|goto|switch|try|catch|return|break|case|continue|default))\\s*\\()((?:(?:(?:(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F]))(?:(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F])))*|::))+|(?<=operator)(?:\\+\\+|\\-\\-|\\(\\)|\\[\\]|\\->|\\+\\+|\\-\\-|\\+|\\-|!|~|\\*|&|new|new\\[\\]|delete|delete\\[\\]|\\->\\*|\\*|\\/|%|\\+|\\-|<<|>>|<=>|<|<=|>|>=|==|!=|&|\\^|\\||&&|\\|\\||=|\\+=|\\-=|\\*=|\\/=|%=|<<=|>>=|&=|\\^=|\\|=|,)))\\s*(\\()",
           "beginCaptures": {
             "1": {
               "name": "entity.name.function.cpp"
@@ -4221,9 +4221,9 @@
               "name": "punctuation.section.parameters.begin.bracket.round.cpp"
             }
           },
-          "end": "(?-mix:\\)|:)",
+          "end": "(\\)|:)",
           "endCaptures": {
-            "0": {
+            "1": {
               "name": "punctuation.section.parameters.end.bracket.round.cpp"
             }
           },

--- a/syntaxes/cpp.tmLanguage.yaml
+++ b/syntaxes/cpp.tmLanguage.yaml
@@ -2333,23 +2333,15 @@
     - include: "#operators"
     - include: "#vararg_ellipses"
     - name: meta.function.definition.parameters.cpp
-      begin: |-
-        (?x)
-        (?!(?:while|for|do|if|else|switch|catch|return|typeid|alignof|alignas|sizeof|and|and_eq|bitand|bitor|compl|not|not_eq|or|or_eq|typeid|xor|xor_eq|alignof|alignas)\s*\()
-        (
-        (?:[A-Za-z_][A-Za-z0-9_]*+|::)++ # actual name
-        |
-        (?:(?<=operator)(?:[-*&<>=+!]+|\(\)|\[\]))
-        )
-        \s*(\()
+      begin: "(?!(?:(?:::|\\+\\+|\\-\\-|\\(\\)|\\[\\]|\\.|\\->|\\+\\+|\\-\\-|\\+|\\-|!|not|~|compl|\\*|&|sizeof|sizeof\\.\\.\\.|new|new\\[\\]|delete|delete\\[\\]|\\.\\*|\\->\\*|\\*|\\/|%|\\+|\\-|<<|>>|<=>|<|<=|>|>=|==|!=|not_eq|&|bitand|\\^|xor|\\||bitor|&&|and|\\|\\||or|\\?:|throw|=|\\+=|\\-=|\\*=|\\/=|%=|<<=|>>=|&=|and_eq|\\^=|xor_eq|\\|=|or_eq|,|alignof|alignas|typeid|noexcept|static_cast|dynamic_cast|const_cast|reinterpret_cast)|(?:throw|while|for|do|if|else|goto|switch|try|catch|return|break|case|continue|default))\\s*\\()((?:(?:(?:(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F]))(?:(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F])))*|::))+|(?<=operator)(?:\\+\\+|\\-\\-|\\(\\)|\\[\\]|\\->|\\+\\+|\\-\\-|\\+|\\-|!|~|\\*|&|new|new\\[\\]|delete|delete\\[\\]|\\->\\*|\\*|\\/|%|\\+|\\-|<<|>>|<=>|<|<=|>|>=|==|!=|&|\\^|\\||&&|\\|\\||=|\\+=|\\-=|\\*=|\\/=|%=|<<=|>>=|&=|\\^=|\\|=|,)))\\s*(\\()"
       beginCaptures:
         '1':
           name: entity.name.function.cpp
         '2':
           name: punctuation.section.parameters.begin.bracket.round.cpp
-      end: !ruby/regexp /\)|:/
+      end: "(\\)|:)"
       endCaptures:
-        '0':
+        '1':
           name: punctuation.section.parameters.end.bracket.round.cpp
       patterns:
       - include: "#probably_a_parameter"

--- a/syntaxes/cpp.tmLanguage.yaml
+++ b/syntaxes/cpp.tmLanguage.yaml
@@ -677,6 +677,21 @@
         name: punctuation.section.arguments.end.bracket.round.cpp
     patterns:
     - include: "#function_call_context_c"
+  legacy_function_definition:
+    name: meta.function.definition.parameters.cpp
+    begin: "(?!(?:(?:::|\\+\\+|\\-\\-|\\(\\)|\\[\\]|\\.|\\->|\\+\\+|\\-\\-|\\+|\\-|!|not|~|compl|\\*|&|sizeof|sizeof\\.\\.\\.|new|new\\[\\]|delete|delete\\[\\]|\\.\\*|\\->\\*|\\*|\\/|%|\\+|\\-|<<|>>|<=>|<|<=|>|>=|==|!=|not_eq|&|bitand|\\^|xor|\\||bitor|&&|and|\\|\\||or|\\?:|throw|=|\\+=|\\-=|\\*=|\\/=|%=|<<=|>>=|&=|and_eq|\\^=|xor_eq|\\|=|or_eq|,|alignof|alignas|typeid|noexcept|static_cast|dynamic_cast|const_cast|reinterpret_cast)|(?:throw|while|for|do|if|else|goto|switch|try|catch|return|break|case|continue|default))\\s*\\()((?:(?:(?:(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F]))(?:(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F])))*|::))+|(?<=operator)(?:\\+\\+|\\-\\-|\\(\\)|\\[\\]|\\->|\\+\\+|\\-\\-|\\+|\\-|!|~|\\*|&|new|new\\[\\]|delete|delete\\[\\]|\\->\\*|\\*|\\/|%|\\+|\\-|<<|>>|<=>|<|<=|>|>=|==|!=|&|\\^|\\||&&|\\|\\||=|\\+=|\\-=|\\*=|\\/=|%=|<<=|>>=|&=|\\^=|\\|=|,)))\\s*(\\()"
+    beginCaptures:
+      '1':
+        name: entity.name.function.cpp
+      '2':
+        name: punctuation.section.parameters.begin.bracket.round.cpp
+    end: "(\\)|:)"
+    endCaptures:
+      '1':
+        name: punctuation.section.parameters.end.bracket.round.cpp
+    patterns:
+    - include: "#probably_a_parameter"
+    - include: "#function_context_c"
   operators:
     patterns:
     - include: "#sizeof_operator"
@@ -2332,20 +2347,7 @@
     - include: "#storage_types"
     - include: "#operators"
     - include: "#vararg_ellipses"
-    - name: meta.function.definition.parameters.cpp
-      begin: "(?!(?:(?:::|\\+\\+|\\-\\-|\\(\\)|\\[\\]|\\.|\\->|\\+\\+|\\-\\-|\\+|\\-|!|not|~|compl|\\*|&|sizeof|sizeof\\.\\.\\.|new|new\\[\\]|delete|delete\\[\\]|\\.\\*|\\->\\*|\\*|\\/|%|\\+|\\-|<<|>>|<=>|<|<=|>|>=|==|!=|not_eq|&|bitand|\\^|xor|\\||bitor|&&|and|\\|\\||or|\\?:|throw|=|\\+=|\\-=|\\*=|\\/=|%=|<<=|>>=|&=|and_eq|\\^=|xor_eq|\\|=|or_eq|,|alignof|alignas|typeid|noexcept|static_cast|dynamic_cast|const_cast|reinterpret_cast)|(?:throw|while|for|do|if|else|goto|switch|try|catch|return|break|case|continue|default))\\s*\\()((?:(?:(?:(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F]))(?:(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F])))*|::))+|(?<=operator)(?:\\+\\+|\\-\\-|\\(\\)|\\[\\]|\\->|\\+\\+|\\-\\-|\\+|\\-|!|~|\\*|&|new|new\\[\\]|delete|delete\\[\\]|\\->\\*|\\*|\\/|%|\\+|\\-|<<|>>|<=>|<|<=|>|>=|==|!=|&|\\^|\\||&&|\\|\\||=|\\+=|\\-=|\\*=|\\/=|%=|<<=|>>=|&=|\\^=|\\|=|,)))\\s*(\\()"
-      beginCaptures:
-        '1':
-          name: entity.name.function.cpp
-        '2':
-          name: punctuation.section.parameters.begin.bracket.round.cpp
-      end: "(\\)|:)"
-      endCaptures:
-        '1':
-          name: punctuation.section.parameters.end.bracket.round.cpp
-      patterns:
-      - include: "#probably_a_parameter"
-      - include: "#function_context_c"
+    - include: "#legacy_function_definition"
     - begin: "\\("
       beginCaptures:
         '0':

--- a/test/specs/issues/017.cpp.yaml
+++ b/test/specs/issues/017.cpp.yaml
@@ -126,15 +126,45 @@
 - source: void
   scopes:
     - storage.type.primitive.cpp
-- source: Line\u00b7Reader();
+- source: Line\u00b7Reader
   scopesBegin:
     - meta.function.definition.parameters.cpp
+    - meta.function.definition.parameters.cpp
+  scopes:
+    - entity.name.function
+- source: (
+  scopes:
+    - punctuation.section.parameters.begin.bracket.round.cpp
+- source: )
+  scopes:
+    - punctuation.section.parameters.end.bracket.round.cpp
+  scopesEnd:
+    - meta.function.definition.parameters.cpp
+    - meta.function.definition.parameters.cpp
+- source: ;
+  scopes:
+    - punctuation.terminator.statement.cpp
 - source: void
   scopes:
     - storage.type.primitive.cpp
-- source: Line\U0002070EReader();
+- source: Line\U0002070EReader
   scopesBegin:
     - meta.function.definition.parameters.cpp
+    - meta.function.definition.parameters.cpp
+  scopes:
+    - entity.name.function
+- source: (
+  scopes:
+    - punctuation.section.parameters.begin.bracket.round.cpp
+- source: )
+  scopes:
+    - punctuation.section.parameters.end.bracket.round.cpp
+  scopesEnd:
+    - meta.function.definition.parameters.cpp
+    - meta.function.definition.parameters.cpp
+- source: ;
+  scopes:
+    - punctuation.terminator.statement.cpp
 - source: namespace
   scopesBegin:
     - meta.block.namespace.cpp


### PR DESCRIPTION
This fixes the last issue of #17, function names.

The pattern on line 3012 was made non-possessive due to #127, but that did not affect the tests.