### PR TITLE
fix access-specifier scope has colon

### DIFF
--- a/cpp/generate.rb
+++ b/cpp/generate.rb
@@ -255,6 +255,7 @@ cpp_grammar = Grammar.new(
         tag_as: "storage.modifier.specifier.$match"
         )
     cpp_grammar[:access_control_keywords] = newPattern(
+        tag_as: "storage.type.modifier.access.control.$reference(access_specifier)",
         match: lookBehindToAvoid(@standard_character).then(
                 match: @cpp_tokens.that(:isAccessSpecifier),
                 reference: "access_specifier"
@@ -262,7 +263,6 @@ cpp_grammar = Grammar.new(
                 match: /:/,
                 tag_as: "colon"
             ),
-        tag_as: "storage.type.modifier.access.control.$reference(access_specifier)",
         )
     cpp_grammar[:exception_keywords] = newPattern(
         match: variableBounds[ @cpp_tokens.that(:isExceptionRelated) ],

--- a/cpp/generate.rb
+++ b/cpp/generate.rb
@@ -255,14 +255,14 @@ cpp_grammar = Grammar.new(
         tag_as: "storage.modifier.specifier.$match"
         )
     cpp_grammar[:access_control_keywords] = newPattern(
-        match: lookBehindToAvoid(@standard_character).then(@cpp_tokens.that(:isAccessSpecifier)).maybe(@spaces).then(/:/),
-        tag_as: "storage.type.modifier.access.control.$match",
-        includes: [
-            newPattern(
+        match: lookBehindToAvoid(@standard_character).then(
+                match: @cpp_tokens.that(:isAccessSpecifier),
+                reference: "access_specifier"
+            ).maybe(@spaces).then(
                 match: /:/,
-                tag_as: "colon.cpp"
-            )
-        ]
+                tag_as: "colon"
+            ),
+        tag_as: "storage.type.modifier.access.control.$reference(access_specifier)",
         )
     cpp_grammar[:exception_keywords] = newPattern(
         match: variableBounds[ @cpp_tokens.that(:isExceptionRelated) ],

--- a/cpp/tags.txt
+++ b/cpp/tags.txt
@@ -267,7 +267,7 @@ storage.type.enum.enum-key.$3.cpp
 storage.type.extern.cpp
 storage.type.integral.$12.cpp
 storage.type.modifier.access.$0.cpp
-storage.type.modifier.access.control.$0.cpp
+storage.type.modifier.access.control.$1.cpp
 storage.type.modifier.final.cpp
 storage.type.namespace.definition.cpp
 storage.type.namespace.directive.cpp

--- a/syntaxes/cpp.tmLanguage.json
+++ b/syntaxes/cpp.tmLanguage.json
@@ -653,18 +653,13 @@
       "name": "storage.modifier.specifier.$0.cpp"
     },
     "access_control_keywords": {
-      "match": "(?<!\\w)(?:private|protected|public)\\s*:",
+      "match": "(?<!\\w)((?:private|protected|public))\\s*(:)",
       "captures": {
-        "0": {
-          "name": "storage.type.modifier.access.control.$0.cpp",
-          "patterns": [
-            {
-              "match": ":",
-              "name": "colon.cpp"
-            }
-          ]
+        "2": {
+          "name": "colon.cpp"
         }
-      }
+      },
+      "name": "storage.type.modifier.access.control.$1.cpp"
     },
     "exception_keywords": {
       "match": "(?<!\\w)(?:throw|try|catch)(?!\\w)",

--- a/syntaxes/cpp.tmLanguage.yaml
+++ b/syntaxes/cpp.tmLanguage.yaml
@@ -338,13 +338,11 @@
     match: "(?<!\\w)(?:const|static|volatile|register|restrict|extern)(?!\\w)"
     name: storage.modifier.specifier.$0.cpp
   access_control_keywords:
-    match: "(?<!\\w)(?:private|protected|public)\\s*:"
+    match: "(?<!\\w)((?:private|protected|public))\\s*(:)"
     captures:
-      '0':
-        name: storage.type.modifier.access.control.$0.cpp
-        patterns:
-        - match: ":"
-          name: colon.cpp
+      '2':
+        name: colon.cpp
+    name: storage.type.modifier.access.control.$1.cpp
   exception_keywords:
     match: "(?<!\\w)(?:throw|try|catch)(?!\\w)"
     name: keyword.control.exception.$0.cpp

--- a/test/specs/issues/015.cpp.yaml
+++ b/test/specs/issues/015.cpp.yaml
@@ -17,11 +17,9 @@
     - meta.body.class.cpp
   scopes:
     - storage.type.modifier.access.control.public
-    - ':.cpp'
 - source: ':'
   scopes:
     - storage.type.modifier.access.control.public
-    - ':.cpp'
     - colon
 - source: '}'
   scopes:

--- a/test/specs/vscode/test.cpp.json
+++ b/test/specs/vscode/test.cpp.json
@@ -287,7 +287,7 @@
 	},
 	{
 		"c": "public",
-		"t": "source.cpp meta.block.class.cpp meta.body.class.cpp storage.type.modifier.access.control.public:.cpp",
+		"t": "source.cpp meta.block.class.cpp meta.body.class.cpp storage.type.modifier.access.control.public.cpp",
 		"r": {
 			"dark_plus": "storage.type: #569CD6",
 			"light_plus": "storage.type: #0000FF",
@@ -298,7 +298,7 @@
 	},
 	{
 		"c": ":",
-		"t": "source.cpp meta.block.class.cpp meta.body.class.cpp storage.type.modifier.access.control.public:.cpp colon.cpp",
+		"t": "source.cpp meta.block.class.cpp meta.body.class.cpp storage.type.modifier.access.control.public.cpp colon.cpp",
 		"r": {
 			"dark_plus": "storage.type: #569CD6",
 			"light_plus": "storage.type: #0000FF",


### PR DESCRIPTION
In the example

class Foo {
  public:
  /* snip */
};

public had the scope storage.type.modifier.access.control.public:.
even worse when there is a space between public and : public had the scope storage.type.modifier.access.control.public.cpp :.cpp.

This PR prevents the `:` from ending up as part of the scope name.