### PR TITLE
version bump to match match marketplace

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "better-cpp-syntax",
-    "version": "1.8.13",
+    "version": "1.8.14",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -8,9 +8,12 @@
         "build": "ruby cpp/generate.rb && ruby c/generate.rb",
         "pretest": "npm run build",
         "test": "node test/src/commands/test.js",
+        "preversion": "npm test",
+        "version": "npm run build && git add -A syntaxes",
         "pregenerate-specs": "npm run build",
         "generate-specs": "node test/src/commands/generate-specs.js",
-        "sort-specs": "node test/src/commands/sort-specs.js"
+        "sort-specs": "node test/src/commands/sort-specs.js",
+        "vscode:prepublish": "npm run build"
     },
     "engines": {
         "vscode": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "Better C++ Syntax",
     "description": "The bleeding edge of the VS Code C++ syntax",
     "icon": "icon.png",
-    "version": "1.8.13",
+    "version": "1.8.14",
     "scripts": {
         "build": "ruby cpp/generate.rb && ruby c/generate.rb",
         "pretest": "npm run build",


### PR DESCRIPTION
The marketplace has version 1.8.14, but that does not exist in the source code, this PR performs a version bump so that they are in sync again.

Additionally, this PR tries to prevent reoccurrence of https://github.com/jeff-hykin/cpp-textmate-grammar/issues/150#issuecomment-490718510 where a published version does not have the updated syntax files. This PR ensures that `npm run build` is ran before publishing to the marketplace and after a version bump.

The second commit of this PR was created by `npm version`