### PR TITLE
Add regex pattern coverage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -278,6 +278,12 @@
                 "esprima": "^4.0.0"
             }
         },
+        "json-source-map": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/json-source-map/-/json-source-map-0.4.0.tgz",
+            "integrity": "sha1-7qg3/jzi8r/VsTaHd5QGNUQjw1U=",
+            "dev": true
+        },
         "json-stable-stringify": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
@@ -360,9 +366,9 @@
             "dev": true
         },
         "nan": {
-            "version": "2.13.2",
-            "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
-            "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==",
+            "version": "2.14.0",
+            "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+            "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
             "dev": true
         },
         "nice-try": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "scripts": {
         "build": "ruby cpp/generate.rb && ruby c/generate.rb",
         "pretest": "npm run build",
+        "cov": "npm run test --coverage",
         "test": "node test/src/commands/test.js",
         "preversion": "npm test",
         "version": "npm run build && git add -A syntaxes",

--- a/package.json
+++ b/package.json
@@ -47,8 +47,10 @@
         "chalk": "^2.4.2",
         "glob": "^7.1.3",
         "js-yaml": "^3.13.1",
+        "json-source-map": "^0.4.0",
         "json-stable-stringify": "^1.0.1",
         "lodash": "^4.17.11",
+        "oniguruma": "^7.1.0",
         "prettyjson": "^1.2.1",
         "vscode-textmate": "^4.1.1",
         "yargs": "^13.2.2"

--- a/test/src/arguments.js
+++ b/test/src/arguments.js
@@ -18,5 +18,10 @@ module.exports = require("yargs")
         type: "boolean",
         describe: "treat .h as source.c"
     })
+    .option("coverage", {
+        default: false,
+        type: "boolean",
+        describe: "display the code coverage on running a test"
+    })
     .strict()
     .example("$0 issues/002.cpp").argv;

--- a/test/src/commands/test.js
+++ b/test/src/commands/test.js
@@ -41,6 +41,8 @@ async function runTests() {
         console.groupEnd();
     }
     console.log();
-    coverage.reportAllRecorders();
+    if (argv.coverage) {
+        coverage.reportAllRecorders();
+    }
     process.exit(totalResult ? 0 : 1);
 }

--- a/test/src/commands/test.js
+++ b/test/src/commands/test.js
@@ -6,7 +6,10 @@ const yaml = require("js-yaml");
 const runTest = require("../testRunner");
 const argv = require("../arguments");
 const paths = require("../paths");
-const registry = require("../registry");
+const registry = require("../registry").getRegistry(
+    require("../pattern-coverage/oniguruma-decorator").getOniguruma
+);
+const coverage = require("../pattern-coverage/patternCoverage");
 
 const tests = require("../getTests")(
     test =>
@@ -37,5 +40,7 @@ async function runTests() {
         totalResult = result ? totalResult : result;
         console.groupEnd();
     }
+    console.log();
+    coverage.reportAllRecorders();
     process.exit(totalResult ? 0 : 1);
 }

--- a/test/src/pattern-coverage/onigScanner.js
+++ b/test/src/pattern-coverage/onigScanner.js
@@ -71,7 +71,8 @@ module.exports = class OnigScanner {
                 result.line,
                 result.matchTime,
                 result.chosen,
-                result.match === null
+                result.match === null,
+                this.patterns.length === 1
             );
         }
         // use a genuine OnigScanner return as the results are slightly different

--- a/test/src/pattern-coverage/oniguruma-decorator.js
+++ b/test/src/pattern-coverage/oniguruma-decorator.js
@@ -1,0 +1,63 @@
+// This file wraps an IOnigLib and collects information to provide pattern coverage statistics
+const onigLibs = require("vscode-textmate");
+const OnigScanner = require("./onigScanner");
+const coverage = require("./patternCoverage");
+
+// from vscode-textmate src/onigLibs.ts
+let onigurumaLib = null;
+function getOniguruma() {
+    if (!onigurumaLib) {
+        let getOnigModule = (function() {
+            var onigurumaModule = null;
+            return function() {
+                if (!onigurumaModule) {
+                    onigurumaModule = require("oniguruma");
+                }
+                return onigurumaModule;
+            };
+        })();
+        onigurumaLib = Promise.resolve({
+            createOnigScanner(patterns) {
+                let onigurumaModule = getOnigModule();
+                return new onigurumaModule.OnigScanner(patterns);
+            },
+            createOnigString(s) {
+                let onigurumaModule = getOnigModule();
+                let string = new onigurumaModule.OnigString(s);
+                string.content = s;
+                return string;
+            }
+        });
+    }
+    return onigurumaLib;
+}
+
+module.exports = {
+    /**
+     * @returns {onigLibs.Thenable<onigLibs.IOnigLib>}
+     */
+    getOniguruma: async function() {
+        const oniguruma = await getOniguruma();
+        return {
+            /**
+             * @param {string[]} patterns
+             */
+            createOnigScanner: patterns => {
+                // grab scopeName from first pattern
+                const scopeName = patterns[0].match(
+                    /^\(\?#(source\..+):\d+\)/
+                )[1];
+                return new OnigScanner(
+                    patterns,
+                    coverage.getRecorder(scopeName)
+                );
+            },
+            /**
+             * @param {string} s
+             */
+            createOnigString: s => {
+                return oniguruma.createOnigString(s);
+            }
+        };
+    }
+};

--- a/test/src/pattern-coverage/patternCoverage.js
+++ b/test/src/pattern-coverage/patternCoverage.js
@@ -1,0 +1,85 @@
+// stores coverage results for grammars
+const jsonSourceMap = require("json-source-map");
+const _ = require("lodash");
+
+class patternCoverage {
+    /**
+     * @typedef {{source: string, count: number[], sumTime: number[]}} Coverage
+     */
+    constructor(grammar, scopeName) {
+        // converts a grammar into a list of pointers which become an array of coverage objects
+        const pointers = jsonSourceMap.parse(grammar).pointers;
+        /**
+         * @type {{[source: string]: Coverage}}
+         */
+        this.coverage = [];
+        this.scopeName = scopeName;
+        this.empty = true;
+        for (const pointer of Object.keys(pointers)) {
+            if (/(?:match|begin|end|while)$/.test(pointer)) {
+                const source = scopeName + ":" + pointers[pointer].key.line;
+                this.coverage[source] = {
+                    source,
+                    // order is failure, unchosen, chosen
+                    count: [0, 0, 0],
+                    sumTime: [0, 0, 0]
+                };
+            }
+        }
+    }
+    record(source, time, chosen, failure) {
+        this.empty = false;
+        const index = failure ? 0 : chosen ? 2 : 1;
+        this.coverage[source].count[index] += 1;
+        this.coverage[source].sumTime[index] += time;
+    }
+    report() {
+        let averages = [0, 0, 0];
+        for (const coverage of Object.values(this.coverage)) {
+            if (coverage.count[0] > 0) {
+                averages[0] += 1;
+            }
+            if (coverage.count[1] > 0) {
+                averages[1] += 1;
+            }
+            if (coverage.count[2] > 0) {
+                averages[2] += 1;
+            }
+        }
+        averages[0] /= Object.keys(this.coverage).length;
+        averages[1] /= Object.keys(this.coverage).length;
+        averages[2] /= Object.keys(this.coverage).length;
+        console.log(
+            "code coverage for %s:\n\t%f%% / %f%% / %f%% / %f%%\n\t(match failure / match not chosen / match chosen / average)",
+            this.scopeName,
+            (averages[0] * 100).toFixed(2),
+            (averages[1] * 100).toFixed(2),
+            (averages[2] * 100).toFixed(2),
+            (_.mean(averages) * 100).toFixed(2)
+        );
+    }
+    isEmpty() {
+        return this.empty;
+    }
+}
+
+let recorders = {};
+
+module.exports = {
+    loadRecorder: function(grammar, scopeName) {
+        if (recorders[scopeName]) {
+            return;
+        }
+        recorders[scopeName] = new patternCoverage(grammar, scopeName);
+    },
+    getRecorder: function(scopeName) {
+        return recorders[scopeName];
+    },
+    reportAllRecorders: function() {
+        for (const recorder of Object.values(recorders)) {
+            if (!recorder.isEmpty()) {
+                recorder.report();
+            }
+        }
+    }
+};

--- a/test/src/pattern-coverage/patternCoverage.js
+++ b/test/src/pattern-coverage/patternCoverage.js
@@ -27,11 +27,15 @@ class patternCoverage {
             }
         }
     }
-    record(source, time, chosen, failure) {
+    record(source, time, chosen, failure, onlyPattern) {
         this.empty = false;
         const index = failure ? 0 : chosen ? 2 : 1;
         this.coverage[source].count[index] += 1;
         this.coverage[source].sumTime[index] += time;
+        if (onlyPattern && chosen) {
+            this.coverage[source].count[1] += 1;
+            this.coverage[source].sumTime[1] += time;
+        }
     }
     report() {
         let averages = [0, 0, 0];
@@ -39,6 +43,7 @@ class patternCoverage {
             if (coverage.count[0] > 0) {
                 averages[0] += 1;
             }
+            // if the recorded pattern is the only pattern in the set, don't count matched unChosen against it
             if (coverage.count[1] > 0) {
                 averages[1] += 1;
             }

--- a/test/src/pattern-coverage/rewriteGrammar.js
+++ b/test/src/pattern-coverage/rewriteGrammar.js
@@ -1,0 +1,101 @@
+// this modifies each rule so that regular expressions have their line numbers in them
+const jsonSourceMap = require("json-source-map");
+const vsctm = require("vscode-textmate");
+const coverage = require("./patternCoverage");
+
+/**
+ * @param {Object} pointers
+ * @param {vsctm.IRawRule} rule
+ * @param {string} jsonPointer
+ */
+function rewriteRule(rule, jsonPointer, pointers, scopeName) {
+    if (rule.match) {
+        rule.match = `(?#${scopeName}:${
+            pointers[jsonPointer + "/match"].key.line
+        })${rule.match}`;
+    }
+    if (rule.begin) {
+        rule.begin = `(?#${scopeName}:${
+            pointers[jsonPointer + "/begin"].key.line
+        })${rule.begin}`;
+    }
+    if (rule.end) {
+        rule.end = `(?#${scopeName}:${
+            pointers[jsonPointer + "/end"].key.line
+        })${rule.end}`;
+    }
+    if (rule.while) {
+        rule.while = `(?#${scopeName}:${
+            pointers[jsonPointer + "/while"].key.line
+        })${rule.while}`;
+    }
+    if (rule.patterns) {
+        rule.patterns.map((r, indx) =>
+            rewriteRule(
+                r,
+                jsonPointer + "/patterns/" + indx,
+                pointers,
+                scopeName
+            )
+        );
+    }
+    if (rule.captures) {
+        Object.keys(rule.captures).map(key => {
+            rewriteRule(
+                rule.captures[key],
+                jsonPointer + "/captures/" + key,
+                pointers,
+                scopeName
+            );
+        });
+    }
+    if (rule.beginCaptures) {
+        Object.keys(rule.beginCaptures).map(key => {
+            rewriteRule(
+                rule.beginCaptures[key],
+                jsonPointer + "/beginCaptures/" + key,
+                pointers,
+                scopeName
+            );
+        });
+    }
+    if (rule.endCaptures) {
+        Object.keys(rule.endCaptures).map(key => {
+            rewriteRule(
+                rule.endCaptures[key],
+                jsonPointer + "/endCaptures/" + key,
+                pointers,
+                scopeName
+            );
+        });
+    }
+    if (rule.whileCaptures) {
+        Object.keys(rule.whileCaptures).map(key => {
+            rewriteRule(
+                rule.whileCaptures[key],
+                jsonPointer + "/whileCaptures/" + key,
+                pointers,
+                scopeName
+            );
+        });
+    }
+}
+/**
+ * @param {string} grammar
+ * @param {string} scopeName
+ * @returns {vsctm.IRawGrammar}
+ */
+module.exports = function(grammar, scopeName) {
+    const result = jsonSourceMap.parse(grammar);
+    rewriteRule(result.data, "", result.pointers, scopeName);
+    Object.keys(result.data["repository"]).map(name => {
+        rewriteRule(
+            result.data["repository"][name],
+            `/repository/${name}`,
+            result.pointers,
+            scopeName
+        );
+    });
+    coverage.loadRecorder(grammar, scopeName);
+    return result.data;
+};

--- a/test/src/registry.js
+++ b/test/src/registry.js
@@ -1,33 +1,44 @@
 const path = require("path");
 const fs = require("fs");
 const vsctm = require("vscode-textmate");
+const rewriteGrammar = require("./pattern-coverage/rewriteGrammar");
 
 const testDir = path.dirname(__dirname);
 
-// load the grammars
-module.exports = new vsctm.Registry({
-    loadGrammar: scopeName => {
-        let grammarPath = "";
-        switch (scopeName) {
-            case "source.cpp":
-                grammarPath = path.join(
-                    testDir,
-                    "../syntaxes",
-                    "cpp.tmLanguage.json"
-                );
-                break;
-            case "source.c":
-                grammarPath = path.join(
-                    testDir,
-                    "../syntaxes",
-                    "c.tmLanguage.json"
-                );
-                break;
-            default:
-                return Promise.reject("requested non c/c++ grammar");
-        }
-        return Promise.resolve(
-            vsctm.parseRawGrammar(fs.readFileSync(grammarPath), grammarPath)
-        );
-    }
-});
+function getRegistry(getOnigLib) {
+    return new vsctm.Registry({
+        loadGrammar: scopeName => {
+            let grammarPath = "";
+            switch (scopeName) {
+                case "source.cpp":
+                    grammarPath = path.join(
+                        testDir,
+                        "../syntaxes",
+                        "cpp.tmLanguage.json"
+                    );
+                    break;
+                case "source.c":
+                    grammarPath = path.join(
+                        testDir,
+                        "../syntaxes",
+                        "c.tmLanguage.json"
+                    );
+                    break;
+                default:
+                    return Promise.reject("requested non c/c++ grammar");
+            }
+            return Promise.resolve(
+                rewriteGrammar(
+                    fs.readFileSync(grammarPath).toString(),
+                    scopeName
+                )
+            );
+        },
+        getOnigLib
+    });
+}
+
+module.exports = {
+    getRegistry,
+    default: getRegistry(undefined)
+};


### PR DESCRIPTION
This PR adds a pattern coverage report to the end of npm test. Example output:
![Screenshot from 2019-05-19 22-54-30](https://user-images.githubusercontent.com/714007/57999128-1c92c600-7a89-11e9-9274-3f6e68299e07.png)

This was achieved by wrapping the requested OnigLib with a object that returns a custom implementation of an OnigScanner. This scanner manually tests for the matching pattern. By doing this the custom scanner can record what patterns were chosen and what patterns failed to match at all. To ensure that the test quality is not compromised. A genuine OnigScanner is used to give the results to vscode-textmate. A comment containing the original location of each pattern is added in by rewriteGrammar to different patterns that are identical but in different locations,
