### PR TITLE
add count of patterns never considered

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
         "build": "ruby cpp/generate.rb && ruby c/generate.rb",
         "pretest": "npm run build",
         "test": "node test/src/commands/test.js",
+        "cov": "npm test -- --coverage",
         "preversion": "npm test",
         "version": "npm run build && git add -A syntaxes",
         "pregenerate-specs": "npm run build",

--- a/test/src/arguments.js
+++ b/test/src/arguments.js
@@ -2,6 +2,7 @@ module.exports = require("yargs")
     .usage("Usage: $0 [options] [fixture]")
     .wrap(require("yargs").terminalWidth())
     .demandCommand(0)
+    // --color is parsed by chalk
     .option("color", {
         default: true,
         describe: "enable color",
@@ -17,6 +18,11 @@ module.exports = require("yargs")
         default: false,
         type: "boolean",
         describe: "treat .h as source.c"
+    })
+    .option("coverage", {
+        default: false,
+        type: "boolean",
+        describe: "display code coverage on running a test"
     })
     .strict()
     .example("$0 issues/002.cpp").argv;

--- a/test/src/commands/test.js
+++ b/test/src/commands/test.js
@@ -6,8 +6,11 @@ const yaml = require("js-yaml");
 const runTest = require("../testRunner");
 const argv = require("../arguments");
 const paths = require("../paths");
+
 const registry = require("../registry").getRegistry(
-    require("../pattern-coverage/oniguruma-decorator").getOniguruma
+    argv.coverage
+        ? require("../pattern-coverage/oniguruma-decorator").getOniguruma
+        : undefined
 );
 const coverage = require("../pattern-coverage/patternCoverage");
 

--- a/test/src/pattern-coverage/patternCoverage.js
+++ b/test/src/pattern-coverage/patternCoverage.js
@@ -39,6 +39,7 @@ class patternCoverage {
     }
     report() {
         let averages = [0, 0, 0];
+        let notConsidered = 0;
         for (const coverage of Object.values(this.coverage)) {
             if (coverage.count[0] > 0) {
                 averages[0] += 1;
@@ -50,10 +51,14 @@ class patternCoverage {
             if (coverage.count[2] > 0) {
                 averages[2] += 1;
             }
+            if (_.every(coverage.count, v => v === 0)) {
+                notConsidered += 1;
+            }
         }
-        averages[0] /= Object.keys(this.coverage).length;
-        averages[1] /= Object.keys(this.coverage).length;
-        averages[2] /= Object.keys(this.coverage).length;
+        const totalPatterns = Object.keys(this.coverage).length;
+        averages[0] /= totalPatterns;
+        averages[1] /= totalPatterns;
+        averages[2] /= totalPatterns;
         console.log(
             "code coverage for %s:\n\t%f%% / %f%% / %f%% / %f%%\n\t(match failure / match not chosen / match chosen / average)",
             this.scopeName,
@@ -61,6 +66,11 @@ class patternCoverage {
             (averages[1] * 100).toFixed(2),
             (averages[2] * 100).toFixed(2),
             (_.mean(averages) * 100).toFixed(2)
+        );
+        console.log(
+            "\t%d (%f%%) patterns were never considered",
+            notConsidered,
+            ((notConsidered / totalPatterns) * 100).toFixed(2)
         );
     }
     isEmpty() {


### PR DESCRIPTION
![Screenshot from 2019-05-21 15-51-13](https://user-images.githubusercontent.com/714007/58135705-4f9b9d80-7be0-11e9-86d1-377e3d7ba1fd.png)
This provides a count of the patterns that were never considered.

A pattern is considered to be never considered if it has no counts for, match failure, match not chosen, or match chosen. 