### PR TITLE
add highlighting for typedef when used before class/struct/union

### DIFF
--- a/cpp/generate.rb
+++ b/cpp/generate.rb
@@ -1367,10 +1367,11 @@ cpp_grammar = Grammar.new(
             end_pattern: lookBehindFor(/;/),
             includes: [
                 generateClassOrStructBlockFinder[name, [
-                    newPattern(
+                    ref_deref_definition_pattern.then(
                         match: variable_name,
                         tag_as: "entity.name.type.alias"
-                    )
+                    ),
+                    /,/,
                 ]]
             ]
         )

--- a/cpp/tags.txt
+++ b/cpp/tags.txt
@@ -26,6 +26,7 @@ entity.name.function.preprocessor.cpp
 entity.name.operator.overloadee.cpp
 entity.name.tag.pragma-mark.cpp
 entity.name.type.$3.cpp
+entity.name.type.alias.cpp
 entity.name.type.cpp
 entity.name.type.enum.cpp
 entity.name.type.inherited.cpp
@@ -86,6 +87,7 @@ keyword.other.namespace.definition.cpp
 keyword.other.namespace.directive.cpp
 keyword.other.operator.overload.cpp
 keyword.other.static_assert.cpp
+keyword.other.typedef.cpp
 keyword.other.typename.cpp
 keyword.other.unit.binary.cpp
 keyword.other.unit.exponent.decimal.cpp

--- a/syntaxes/cpp.tmLanguage.json
+++ b/syntaxes/cpp.tmLanguage.json
@@ -2964,8 +2964,21 @@
               "end": "[\\s\\n]*(?=;)",
               "patterns": [
                 {
-                  "match": "(?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F]))(?:(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F])))*(?!\\w)",
-                  "name": "entity.name.type.alias.cpp"
+                  "match": "(((?:\\*\\s*)*)((?:\\&\\s*?){0,2})\\s*)((?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F]))(?:(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F])))*(?!\\w))",
+                  "captures": {
+                    "2": {
+                      "name": "storage.modifier.pointer.cpp"
+                    },
+                    "3": {
+                      "name": "storage.modifier.reference.cpp"
+                    },
+                    "4": {
+                      "name": "entity.name.type.alias.cpp"
+                    }
+                  }
+                },
+                {
+                  "match": ","
                 }
               ]
             }
@@ -3090,8 +3103,21 @@
               "end": "[\\s\\n]*(?=;)",
               "patterns": [
                 {
-                  "match": "(?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F]))(?:(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F])))*(?!\\w)",
-                  "name": "entity.name.type.alias.cpp"
+                  "match": "(((?:\\*\\s*)*)((?:\\&\\s*?){0,2})\\s*)((?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F]))(?:(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F])))*(?!\\w))",
+                  "captures": {
+                    "2": {
+                      "name": "storage.modifier.pointer.cpp"
+                    },
+                    "3": {
+                      "name": "storage.modifier.reference.cpp"
+                    },
+                    "4": {
+                      "name": "entity.name.type.alias.cpp"
+                    }
+                  }
+                },
+                {
+                  "match": ","
                 }
               ]
             }
@@ -3216,8 +3242,21 @@
               "end": "[\\s\\n]*(?=;)",
               "patterns": [
                 {
-                  "match": "(?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F]))(?:(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F])))*(?!\\w)",
-                  "name": "entity.name.type.alias.cpp"
+                  "match": "(((?:\\*\\s*)*)((?:\\&\\s*?){0,2})\\s*)((?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F]))(?:(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F])))*(?!\\w))",
+                  "captures": {
+                    "2": {
+                      "name": "storage.modifier.pointer.cpp"
+                    },
+                    "3": {
+                      "name": "storage.modifier.reference.cpp"
+                    },
+                    "4": {
+                      "name": "entity.name.type.alias.cpp"
+                    }
+                  }
+                },
+                {
+                  "match": ","
                 }
               ]
             }

--- a/syntaxes/cpp.tmLanguage.json
+++ b/syntaxes/cpp.tmLanguage.json
@@ -686,7 +686,7 @@
       "name": "keyword.control.exception.$0.cpp"
     },
     "other_keywords": {
-      "match": "(?<!\\w)(using|typedef)(?!\\w)",
+      "match": "(?<!\\w)(typedef)(?!\\w)",
       "name": "keyword.other.$0.cpp"
     },
     "the_this_keyword": {
@@ -2847,6 +2847,384 @@
         }
       ]
     },
+    "typedef_class": {
+      "begin": "((?<!\\w)typedef(?!\\w))\\s*(?=(?<!\\w)class(?!\\w))",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.other.typedef.cpp"
+        }
+      },
+      "end": "(?<=;)",
+      "patterns": [
+        {
+          "name": "meta.block.class.cpp",
+          "begin": "((((?<!\\w)class(?!\\w))(?:(?:\\s+|((?:(?:(?:\\[\\[.*?\\]\\]|__attribute(?:__)?\\(\\(.*?\\)\\))|__declspec\\(.*?\\))|alignas\\(.*?\\))(?!\\))))|(?={))(?:((?:(?:(?:\\[\\[.*?\\]\\]|__attribute(?:__)?\\(\\(.*?\\)\\))|__declspec\\(.*?\\))|alignas\\(.*?\\))(?!\\))))?\\s*((?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F]))(?:(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F])))*(?!\\w))?(?:\\s+(final)\\s*)?(?:\\s*(:)((?:\\s*(?:,)?\\s*(?:(?:private|protected|public))?\\s*(?:\\s*(?:,)?\\s*(?!(?:private|protected|public))(?-mix:(?:\\s*(?<!\\w)(?=\\w)(?!(?:not|compl|sizeof|new|delete|not_eq|bitand|xor|bitor|and|or|throw|and_eq|xor_eq|or_eq|alignof|alignas|typeid|noexcept|static_cast|dynamic_cast|const_cast|reinterpret_cast|while|for|do|if|else|goto|switch|try|catch|return|break|case|continue|default|NULL|true|false|nullptr|const|static|volatile|register|restrict|extern|inline|constexpr|mutable|friend|explicit|virtual|final|override|volatile|const|noexcept|constexpr|mutable|constexpr|consteval|private|protected|public|if|elif|else|endif|ifdef|ifndef|define|undef|include|line|error|warning|pragma|_Pragma|defined|__has_include|__has_cpp_attribute|this|template|namespace|using|operator|typedef|decltype|typename|asm|__asm__|concept|requires|export|thread_local|atomic_cancel|atomic_commit|atomic_noexcept|co_await|co_return|co_yield|import|module|reflexpr|synchronized|audit|axiom|transaction_safe|transaction_safe_dynamic)(?![\\w])\\s*)(?:(?:(?:(?:(?:\\[\\[.*?\\]\\]|__attribute(?:__)?\\(\\(.*?\\)\\))|__declspec\\(.*?\\))|alignas\\(.*?\\))(?!\\))))?\\s*(?:(?:(?:short|signed|unsigned|long)|(?:class|struct|union|enum))\\s+)*(?:(?:(?:(?:(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F]))(?:(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F])))*\\s*(?:(?-mix:(?:(?<!<)<(?!<)(?:[\\s<>:,\\w])*>\\s*)))?::)*\\s*)(?:(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F]))(?:(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F])))*)\\s*(?:(?:(?<!<)<(?!<)(?:[\\s<>:,\\w])*>\\s*))?(?:::)))?\\s*(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F]))(?:(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F])))*(?:(?-mix:(?:(?<!<)<(?!<)(?:[\\s<>:,\\w])*>\\s*)))?(?![\\w<:.]))))+)*))?))",
+          "beginCaptures": {
+            "1": {
+              "name": "meta.head.class.cpp"
+            },
+            "3": {
+              "name": "storage.type.$3.cpp"
+            },
+            "4": {
+              "patterns": [
+                {
+                  "include": "#attributes_context"
+                },
+                {
+                  "include": "#number_literal"
+                }
+              ]
+            },
+            "5": {
+              "patterns": [
+                {
+                  "include": "#attributes_context"
+                },
+                {
+                  "include": "#number_literal"
+                }
+              ]
+            },
+            "6": {
+              "name": "entity.name.type.$3.cpp"
+            },
+            "7": {
+              "name": "storage.type.modifier.final.cpp"
+            },
+            "8": {
+              "name": "colon.cpp punctuation.separator.inhertance.cpp"
+            },
+            "9": {
+              "patterns": [
+                {
+                  "include": "#inhertance_context"
+                }
+              ]
+            }
+          },
+          "end": "(?:(?:(?<=})\\s*(;)|(;))|(?=[;>\\[\\]=]))",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.terminator.statement.cpp"
+            },
+            "2": {
+              "name": "punctuation.terminator.statement.cpp"
+            }
+          },
+          "patterns": [
+            {
+              "name": "meta.head.class.cpp",
+              "begin": "\\G ?",
+              "end": "((?:\\{|(?=;)))",
+              "endCaptures": {
+                "1": {
+                  "name": "punctuation.section.block.begin.bracket.curly.class.cpp"
+                }
+              },
+              "patterns": [
+                {
+                  "include": "#preprocessor_context"
+                },
+                {
+                  "include": "#inhertance_context"
+                },
+                {
+                  "include": "#template_call_range"
+                },
+                {
+                  "include": "#comments_context"
+                }
+              ]
+            },
+            {
+              "name": "meta.body.class.cpp",
+              "begin": "(?<=\\{)",
+              "end": "(\\})",
+              "endCaptures": {
+                "1": {
+                  "name": "punctuation.section.block.end.bracket.curly.class.cpp"
+                }
+              },
+              "patterns": [
+                {
+                  "include": "#function_pointer"
+                },
+                {
+                  "include": "#constructor_context"
+                },
+                {
+                  "include": "$base"
+                }
+              ]
+            },
+            {
+              "name": "meta.tail.class.cpp",
+              "begin": "(?<=})[\\s\\n]*",
+              "end": "[\\s\\n]*(?=;)",
+              "patterns": [
+                {
+                  "match": "(?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F]))(?:(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F])))*(?!\\w)",
+                  "name": "entity.name.type.alias.cpp"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "typedef_struct": {
+      "begin": "((?<!\\w)typedef(?!\\w))\\s*(?=(?<!\\w)struct(?!\\w))",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.other.typedef.cpp"
+        }
+      },
+      "end": "(?<=;)",
+      "patterns": [
+        {
+          "name": "meta.block.struct.cpp",
+          "begin": "((((?<!\\w)struct(?!\\w))(?:(?:\\s+|((?:(?:(?:\\[\\[.*?\\]\\]|__attribute(?:__)?\\(\\(.*?\\)\\))|__declspec\\(.*?\\))|alignas\\(.*?\\))(?!\\))))|(?={))(?:((?:(?:(?:\\[\\[.*?\\]\\]|__attribute(?:__)?\\(\\(.*?\\)\\))|__declspec\\(.*?\\))|alignas\\(.*?\\))(?!\\))))?\\s*((?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F]))(?:(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F])))*(?!\\w))?(?:\\s+(final)\\s*)?(?:\\s*(:)((?:\\s*(?:,)?\\s*(?:(?:private|protected|public))?\\s*(?:\\s*(?:,)?\\s*(?!(?:private|protected|public))(?-mix:(?:\\s*(?<!\\w)(?=\\w)(?!(?:not|compl|sizeof|new|delete|not_eq|bitand|xor|bitor|and|or|throw|and_eq|xor_eq|or_eq|alignof|alignas|typeid|noexcept|static_cast|dynamic_cast|const_cast|reinterpret_cast|while|for|do|if|else|goto|switch|try|catch|return|break|case|continue|default|NULL|true|false|nullptr|const|static|volatile|register|restrict|extern|inline|constexpr|mutable|friend|explicit|virtual|final|override|volatile|const|noexcept|constexpr|mutable|constexpr|consteval|private|protected|public|if|elif|else|endif|ifdef|ifndef|define|undef|include|line|error|warning|pragma|_Pragma|defined|__has_include|__has_cpp_attribute|this|template|namespace|using|operator|typedef|decltype|typename|asm|__asm__|concept|requires|export|thread_local|atomic_cancel|atomic_commit|atomic_noexcept|co_await|co_return|co_yield|import|module|reflexpr|synchronized|audit|axiom|transaction_safe|transaction_safe_dynamic)(?![\\w])\\s*)(?:(?:(?:(?:(?:\\[\\[.*?\\]\\]|__attribute(?:__)?\\(\\(.*?\\)\\))|__declspec\\(.*?\\))|alignas\\(.*?\\))(?!\\))))?\\s*(?:(?:(?:short|signed|unsigned|long)|(?:class|struct|union|enum))\\s+)*(?:(?:(?:(?:(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F]))(?:(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F])))*\\s*(?:(?-mix:(?:(?<!<)<(?!<)(?:[\\s<>:,\\w])*>\\s*)))?::)*\\s*)(?:(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F]))(?:(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F])))*)\\s*(?:(?:(?<!<)<(?!<)(?:[\\s<>:,\\w])*>\\s*))?(?:::)))?\\s*(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F]))(?:(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F])))*(?:(?-mix:(?:(?<!<)<(?!<)(?:[\\s<>:,\\w])*>\\s*)))?(?![\\w<:.]))))+)*))?))",
+          "beginCaptures": {
+            "1": {
+              "name": "meta.head.struct.cpp"
+            },
+            "3": {
+              "name": "storage.type.$3.cpp"
+            },
+            "4": {
+              "patterns": [
+                {
+                  "include": "#attributes_context"
+                },
+                {
+                  "include": "#number_literal"
+                }
+              ]
+            },
+            "5": {
+              "patterns": [
+                {
+                  "include": "#attributes_context"
+                },
+                {
+                  "include": "#number_literal"
+                }
+              ]
+            },
+            "6": {
+              "name": "entity.name.type.$3.cpp"
+            },
+            "7": {
+              "name": "storage.type.modifier.final.cpp"
+            },
+            "8": {
+              "name": "colon.cpp punctuation.separator.inhertance.cpp"
+            },
+            "9": {
+              "patterns": [
+                {
+                  "include": "#inhertance_context"
+                }
+              ]
+            }
+          },
+          "end": "(?:(?:(?<=})\\s*(;)|(;))|(?=[;>\\[\\]=]))",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.terminator.statement.cpp"
+            },
+            "2": {
+              "name": "punctuation.terminator.statement.cpp"
+            }
+          },
+          "patterns": [
+            {
+              "name": "meta.head.struct.cpp",
+              "begin": "\\G ?",
+              "end": "((?:\\{|(?=;)))",
+              "endCaptures": {
+                "1": {
+                  "name": "punctuation.section.block.begin.bracket.curly.struct.cpp"
+                }
+              },
+              "patterns": [
+                {
+                  "include": "#preprocessor_context"
+                },
+                {
+                  "include": "#inhertance_context"
+                },
+                {
+                  "include": "#template_call_range"
+                },
+                {
+                  "include": "#comments_context"
+                }
+              ]
+            },
+            {
+              "name": "meta.body.struct.cpp",
+              "begin": "(?<=\\{)",
+              "end": "(\\})",
+              "endCaptures": {
+                "1": {
+                  "name": "punctuation.section.block.end.bracket.curly.struct.cpp"
+                }
+              },
+              "patterns": [
+                {
+                  "include": "#function_pointer"
+                },
+                {
+                  "include": "#constructor_context"
+                },
+                {
+                  "include": "$base"
+                }
+              ]
+            },
+            {
+              "name": "meta.tail.struct.cpp",
+              "begin": "(?<=})[\\s\\n]*",
+              "end": "[\\s\\n]*(?=;)",
+              "patterns": [
+                {
+                  "match": "(?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F]))(?:(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F])))*(?!\\w)",
+                  "name": "entity.name.type.alias.cpp"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "typedef_union": {
+      "begin": "((?<!\\w)typedef(?!\\w))\\s*(?=(?<!\\w)union(?!\\w))",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.other.typedef.cpp"
+        }
+      },
+      "end": "(?<=;)",
+      "patterns": [
+        {
+          "name": "meta.block.union.cpp",
+          "begin": "((((?<!\\w)union(?!\\w))(?:(?:\\s+|((?:(?:(?:\\[\\[.*?\\]\\]|__attribute(?:__)?\\(\\(.*?\\)\\))|__declspec\\(.*?\\))|alignas\\(.*?\\))(?!\\))))|(?={))(?:((?:(?:(?:\\[\\[.*?\\]\\]|__attribute(?:__)?\\(\\(.*?\\)\\))|__declspec\\(.*?\\))|alignas\\(.*?\\))(?!\\))))?\\s*((?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F]))(?:(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F])))*(?!\\w))?(?:\\s+(final)\\s*)?(?:\\s*(:)((?:\\s*(?:,)?\\s*(?:(?:private|protected|public))?\\s*(?:\\s*(?:,)?\\s*(?!(?:private|protected|public))(?-mix:(?:\\s*(?<!\\w)(?=\\w)(?!(?:not|compl|sizeof|new|delete|not_eq|bitand|xor|bitor|and|or|throw|and_eq|xor_eq|or_eq|alignof|alignas|typeid|noexcept|static_cast|dynamic_cast|const_cast|reinterpret_cast|while|for|do|if|else|goto|switch|try|catch|return|break|case|continue|default|NULL|true|false|nullptr|const|static|volatile|register|restrict|extern|inline|constexpr|mutable|friend|explicit|virtual|final|override|volatile|const|noexcept|constexpr|mutable|constexpr|consteval|private|protected|public|if|elif|else|endif|ifdef|ifndef|define|undef|include|line|error|warning|pragma|_Pragma|defined|__has_include|__has_cpp_attribute|this|template|namespace|using|operator|typedef|decltype|typename|asm|__asm__|concept|requires|export|thread_local|atomic_cancel|atomic_commit|atomic_noexcept|co_await|co_return|co_yield|import|module|reflexpr|synchronized|audit|axiom|transaction_safe|transaction_safe_dynamic)(?![\\w])\\s*)(?:(?:(?:(?:(?:\\[\\[.*?\\]\\]|__attribute(?:__)?\\(\\(.*?\\)\\))|__declspec\\(.*?\\))|alignas\\(.*?\\))(?!\\))))?\\s*(?:(?:(?:short|signed|unsigned|long)|(?:class|struct|union|enum))\\s+)*(?:(?:(?:(?:(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F]))(?:(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F])))*\\s*(?:(?-mix:(?:(?<!<)<(?!<)(?:[\\s<>:,\\w])*>\\s*)))?::)*\\s*)(?:(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F]))(?:(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F])))*)\\s*(?:(?:(?<!<)<(?!<)(?:[\\s<>:,\\w])*>\\s*))?(?:::)))?\\s*(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F]))(?:(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F])))*(?:(?-mix:(?:(?<!<)<(?!<)(?:[\\s<>:,\\w])*>\\s*)))?(?![\\w<:.]))))+)*))?))",
+          "beginCaptures": {
+            "1": {
+              "name": "meta.head.union.cpp"
+            },
+            "3": {
+              "name": "storage.type.$3.cpp"
+            },
+            "4": {
+              "patterns": [
+                {
+                  "include": "#attributes_context"
+                },
+                {
+                  "include": "#number_literal"
+                }
+              ]
+            },
+            "5": {
+              "patterns": [
+                {
+                  "include": "#attributes_context"
+                },
+                {
+                  "include": "#number_literal"
+                }
+              ]
+            },
+            "6": {
+              "name": "entity.name.type.$3.cpp"
+            },
+            "7": {
+              "name": "storage.type.modifier.final.cpp"
+            },
+            "8": {
+              "name": "colon.cpp punctuation.separator.inhertance.cpp"
+            },
+            "9": {
+              "patterns": [
+                {
+                  "include": "#inhertance_context"
+                }
+              ]
+            }
+          },
+          "end": "(?:(?:(?<=})\\s*(;)|(;))|(?=[;>\\[\\]=]))",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.terminator.statement.cpp"
+            },
+            "2": {
+              "name": "punctuation.terminator.statement.cpp"
+            }
+          },
+          "patterns": [
+            {
+              "name": "meta.head.union.cpp",
+              "begin": "\\G ?",
+              "end": "((?:\\{|(?=;)))",
+              "endCaptures": {
+                "1": {
+                  "name": "punctuation.section.block.begin.bracket.curly.union.cpp"
+                }
+              },
+              "patterns": [
+                {
+                  "include": "#preprocessor_context"
+                },
+                {
+                  "include": "#inhertance_context"
+                },
+                {
+                  "include": "#template_call_range"
+                },
+                {
+                  "include": "#comments_context"
+                }
+              ]
+            },
+            {
+              "name": "meta.body.union.cpp",
+              "begin": "(?<=\\{)",
+              "end": "(\\})",
+              "endCaptures": {
+                "1": {
+                  "name": "punctuation.section.block.end.bracket.curly.union.cpp"
+                }
+              },
+              "patterns": [
+                {
+                  "include": "#function_pointer"
+                },
+                {
+                  "include": "#constructor_context"
+                },
+                {
+                  "include": "$base"
+                }
+              ]
+            },
+            {
+              "name": "meta.tail.union.cpp",
+              "begin": "(?<=})[\\s\\n]*",
+              "end": "[\\s\\n]*(?=;)",
+              "patterns": [
+                {
+                  "match": "(?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F]))(?:(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F])))*(?!\\w)",
+                  "name": "entity.name.type.alias.cpp"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
     "hacky_fix_for_stray_directive": {
       "match": "(?<!\\w)#(?:endif|else|elif)(?!\\w)",
       "name": "keyword.control.directive.$0.cpp"
@@ -3217,6 +3595,15 @@
         },
         {
           "include": "#namespace_block"
+        },
+        {
+          "include": "#typedef_class"
+        },
+        {
+          "include": "#typedef_struct"
+        },
+        {
+          "include": "#typedef_union"
         },
         {
           "include": "#class_block"

--- a/syntaxes/cpp.tmLanguage.yaml
+++ b/syntaxes/cpp.tmLanguage.yaml
@@ -1580,8 +1580,15 @@
         begin: "(?<=})[\\s\\n]*"
         end: "[\\s\\n]*(?=;)"
         patterns:
-        - match: "(?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F]))(?:(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F])))*(?!\\w)"
-          name: entity.name.type.alias.cpp
+        - match: "(((?:\\*\\s*)*)((?:\\&\\s*?){0,2})\\s*)((?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F]))(?:(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F])))*(?!\\w))"
+          captures:
+            '2':
+              name: storage.modifier.pointer.cpp
+            '3':
+              name: storage.modifier.reference.cpp
+            '4':
+              name: entity.name.type.alias.cpp
+        - match: ","
   typedef_struct:
     begin: "((?<!\\w)typedef(?!\\w))\\s*(?=(?<!\\w)struct(?!\\w))"
     beginCaptures:
@@ -1645,8 +1652,15 @@
         begin: "(?<=})[\\s\\n]*"
         end: "[\\s\\n]*(?=;)"
         patterns:
-        - match: "(?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F]))(?:(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F])))*(?!\\w)"
-          name: entity.name.type.alias.cpp
+        - match: "(((?:\\*\\s*)*)((?:\\&\\s*?){0,2})\\s*)((?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F]))(?:(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F])))*(?!\\w))"
+          captures:
+            '2':
+              name: storage.modifier.pointer.cpp
+            '3':
+              name: storage.modifier.reference.cpp
+            '4':
+              name: entity.name.type.alias.cpp
+        - match: ","
   typedef_union:
     begin: "((?<!\\w)typedef(?!\\w))\\s*(?=(?<!\\w)union(?!\\w))"
     beginCaptures:
@@ -1710,8 +1724,15 @@
         begin: "(?<=})[\\s\\n]*"
         end: "[\\s\\n]*(?=;)"
         patterns:
-        - match: "(?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F]))(?:(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F])))*(?!\\w)"
-          name: entity.name.type.alias.cpp
+        - match: "(((?:\\*\\s*)*)((?:\\&\\s*?){0,2})\\s*)((?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F]))(?:(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F])))*(?!\\w))"
+          captures:
+            '2':
+              name: storage.modifier.pointer.cpp
+            '3':
+              name: storage.modifier.reference.cpp
+            '4':
+              name: entity.name.type.alias.cpp
+        - match: ","
   hacky_fix_for_stray_directive:
     match: "(?<!\\w)#(?:endif|else|elif)(?!\\w)"
     name: keyword.control.directive.$0.cpp

--- a/syntaxes/cpp.tmLanguage.yaml
+++ b/syntaxes/cpp.tmLanguage.yaml
@@ -356,7 +356,7 @@
     match: "(?<!\\w)(?:throw|try|catch)(?!\\w)"
     name: keyword.control.exception.$0.cpp
   other_keywords:
-    match: "(?<!\\w)(using|typedef)(?!\\w)"
+    match: "(?<!\\w)(typedef)(?!\\w)"
     name: keyword.other.$0.cpp
   the_this_keyword:
     match: "(?<!\\w)this(?!\\w)"
@@ -1517,6 +1517,201 @@
       patterns:
       - include: "$base"
     - include: "$base"
+  typedef_class:
+    begin: "((?<!\\w)typedef(?!\\w))\\s*(?=(?<!\\w)class(?!\\w))"
+    beginCaptures:
+      '1':
+        name: keyword.other.typedef.cpp
+    end: "(?<=;)"
+    patterns:
+    - name: meta.block.class.cpp
+      begin: "((((?<!\\w)class(?!\\w))(?:(?:\\s+|((?:(?:(?:\\[\\[.*?\\]\\]|__attribute(?:__)?\\(\\(.*?\\)\\))|__declspec\\(.*?\\))|alignas\\(.*?\\))(?!\\))))|(?={))(?:((?:(?:(?:\\[\\[.*?\\]\\]|__attribute(?:__)?\\(\\(.*?\\)\\))|__declspec\\(.*?\\))|alignas\\(.*?\\))(?!\\))))?\\s*((?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F]))(?:(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F])))*(?!\\w))?(?:\\s+(final)\\s*)?(?:\\s*(:)((?:\\s*(?:,)?\\s*(?:(?:private|protected|public))?\\s*(?:\\s*(?:,)?\\s*(?!(?:private|protected|public))(?-mix:(?:\\s*(?<!\\w)(?=\\w)(?!(?:not|compl|sizeof|new|delete|not_eq|bitand|xor|bitor|and|or|throw|and_eq|xor_eq|or_eq|alignof|alignas|typeid|noexcept|static_cast|dynamic_cast|const_cast|reinterpret_cast|while|for|do|if|else|goto|switch|try|catch|return|break|case|continue|default|NULL|true|false|nullptr|const|static|volatile|register|restrict|extern|inline|constexpr|mutable|friend|explicit|virtual|final|override|volatile|const|noexcept|constexpr|mutable|constexpr|consteval|private|protected|public|if|elif|else|endif|ifdef|ifndef|define|undef|include|line|error|warning|pragma|_Pragma|defined|__has_include|__has_cpp_attribute|this|template|namespace|using|operator|typedef|decltype|typename|asm|__asm__|concept|requires|export|thread_local|atomic_cancel|atomic_commit|atomic_noexcept|co_await|co_return|co_yield|import|module|reflexpr|synchronized|audit|axiom|transaction_safe|transaction_safe_dynamic)(?![\\w])\\s*)(?:(?:(?:(?:(?:\\[\\[.*?\\]\\]|__attribute(?:__)?\\(\\(.*?\\)\\))|__declspec\\(.*?\\))|alignas\\(.*?\\))(?!\\))))?\\s*(?:(?:(?:short|signed|unsigned|long)|(?:class|struct|union|enum))\\s+)*(?:(?:(?:(?:(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F]))(?:(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F])))*\\s*(?:(?-mix:(?:(?<!<)<(?!<)(?:[\\s<>:,\\w])*>\\s*)))?::)*\\s*)(?:(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F]))(?:(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F])))*)\\s*(?:(?:(?<!<)<(?!<)(?:[\\s<>:,\\w])*>\\s*))?(?:::)))?\\s*(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F]))(?:(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F])))*(?:(?-mix:(?:(?<!<)<(?!<)(?:[\\s<>:,\\w])*>\\s*)))?(?![\\w<:.]))))+)*))?))"
+      beginCaptures:
+        '1':
+          name: meta.head.class.cpp
+        '3':
+          name: storage.type.$3.cpp
+        '4':
+          patterns:
+          - include: "#attributes_context"
+          - include: "#number_literal"
+        '5':
+          patterns:
+          - include: "#attributes_context"
+          - include: "#number_literal"
+        '6':
+          name: entity.name.type.$3.cpp
+        '7':
+          name: storage.type.modifier.final.cpp
+        '8':
+          name: colon.cpp punctuation.separator.inhertance.cpp
+        '9':
+          patterns:
+          - include: "#inhertance_context"
+      end: "(?:(?:(?<=})\\s*(;)|(;))|(?=[;>\\[\\]=]))"
+      endCaptures:
+        '1':
+          name: punctuation.terminator.statement.cpp
+        '2':
+          name: punctuation.terminator.statement.cpp
+      patterns:
+      - name: meta.head.class.cpp
+        begin: "\\G ?"
+        end: "((?:\\{|(?=;)))"
+        endCaptures:
+          '1':
+            name: punctuation.section.block.begin.bracket.curly.class.cpp
+        patterns:
+        - include: "#preprocessor_context"
+        - include: "#inhertance_context"
+        - include: "#template_call_range"
+        - include: "#comments_context"
+      - name: meta.body.class.cpp
+        begin: "(?<=\\{)"
+        end: "(\\})"
+        endCaptures:
+          '1':
+            name: punctuation.section.block.end.bracket.curly.class.cpp
+        patterns:
+        - include: "#function_pointer"
+        - include: "#constructor_context"
+        - include: "$base"
+      - name: meta.tail.class.cpp
+        begin: "(?<=})[\\s\\n]*"
+        end: "[\\s\\n]*(?=;)"
+        patterns:
+        - match: "(?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F]))(?:(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F])))*(?!\\w)"
+          name: entity.name.type.alias.cpp
+  typedef_struct:
+    begin: "((?<!\\w)typedef(?!\\w))\\s*(?=(?<!\\w)struct(?!\\w))"
+    beginCaptures:
+      '1':
+        name: keyword.other.typedef.cpp
+    end: "(?<=;)"
+    patterns:
+    - name: meta.block.struct.cpp
+      begin: "((((?<!\\w)struct(?!\\w))(?:(?:\\s+|((?:(?:(?:\\[\\[.*?\\]\\]|__attribute(?:__)?\\(\\(.*?\\)\\))|__declspec\\(.*?\\))|alignas\\(.*?\\))(?!\\))))|(?={))(?:((?:(?:(?:\\[\\[.*?\\]\\]|__attribute(?:__)?\\(\\(.*?\\)\\))|__declspec\\(.*?\\))|alignas\\(.*?\\))(?!\\))))?\\s*((?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F]))(?:(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F])))*(?!\\w))?(?:\\s+(final)\\s*)?(?:\\s*(:)((?:\\s*(?:,)?\\s*(?:(?:private|protected|public))?\\s*(?:\\s*(?:,)?\\s*(?!(?:private|protected|public))(?-mix:(?:\\s*(?<!\\w)(?=\\w)(?!(?:not|compl|sizeof|new|delete|not_eq|bitand|xor|bitor|and|or|throw|and_eq|xor_eq|or_eq|alignof|alignas|typeid|noexcept|static_cast|dynamic_cast|const_cast|reinterpret_cast|while|for|do|if|else|goto|switch|try|catch|return|break|case|continue|default|NULL|true|false|nullptr|const|static|volatile|register|restrict|extern|inline|constexpr|mutable|friend|explicit|virtual|final|override|volatile|const|noexcept|constexpr|mutable|constexpr|consteval|private|protected|public|if|elif|else|endif|ifdef|ifndef|define|undef|include|line|error|warning|pragma|_Pragma|defined|__has_include|__has_cpp_attribute|this|template|namespace|using|operator|typedef|decltype|typename|asm|__asm__|concept|requires|export|thread_local|atomic_cancel|atomic_commit|atomic_noexcept|co_await|co_return|co_yield|import|module|reflexpr|synchronized|audit|axiom|transaction_safe|transaction_safe_dynamic)(?![\\w])\\s*)(?:(?:(?:(?:(?:\\[\\[.*?\\]\\]|__attribute(?:__)?\\(\\(.*?\\)\\))|__declspec\\(.*?\\))|alignas\\(.*?\\))(?!\\))))?\\s*(?:(?:(?:short|signed|unsigned|long)|(?:class|struct|union|enum))\\s+)*(?:(?:(?:(?:(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F]))(?:(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F])))*\\s*(?:(?-mix:(?:(?<!<)<(?!<)(?:[\\s<>:,\\w])*>\\s*)))?::)*\\s*)(?:(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F]))(?:(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F])))*)\\s*(?:(?:(?<!<)<(?!<)(?:[\\s<>:,\\w])*>\\s*))?(?:::)))?\\s*(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F]))(?:(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F])))*(?:(?-mix:(?:(?<!<)<(?!<)(?:[\\s<>:,\\w])*>\\s*)))?(?![\\w<:.]))))+)*))?))"
+      beginCaptures:
+        '1':
+          name: meta.head.struct.cpp
+        '3':
+          name: storage.type.$3.cpp
+        '4':
+          patterns:
+          - include: "#attributes_context"
+          - include: "#number_literal"
+        '5':
+          patterns:
+          - include: "#attributes_context"
+          - include: "#number_literal"
+        '6':
+          name: entity.name.type.$3.cpp
+        '7':
+          name: storage.type.modifier.final.cpp
+        '8':
+          name: colon.cpp punctuation.separator.inhertance.cpp
+        '9':
+          patterns:
+          - include: "#inhertance_context"
+      end: "(?:(?:(?<=})\\s*(;)|(;))|(?=[;>\\[\\]=]))"
+      endCaptures:
+        '1':
+          name: punctuation.terminator.statement.cpp
+        '2':
+          name: punctuation.terminator.statement.cpp
+      patterns:
+      - name: meta.head.struct.cpp
+        begin: "\\G ?"
+        end: "((?:\\{|(?=;)))"
+        endCaptures:
+          '1':
+            name: punctuation.section.block.begin.bracket.curly.struct.cpp
+        patterns:
+        - include: "#preprocessor_context"
+        - include: "#inhertance_context"
+        - include: "#template_call_range"
+        - include: "#comments_context"
+      - name: meta.body.struct.cpp
+        begin: "(?<=\\{)"
+        end: "(\\})"
+        endCaptures:
+          '1':
+            name: punctuation.section.block.end.bracket.curly.struct.cpp
+        patterns:
+        - include: "#function_pointer"
+        - include: "#constructor_context"
+        - include: "$base"
+      - name: meta.tail.struct.cpp
+        begin: "(?<=})[\\s\\n]*"
+        end: "[\\s\\n]*(?=;)"
+        patterns:
+        - match: "(?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F]))(?:(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F])))*(?!\\w)"
+          name: entity.name.type.alias.cpp
+  typedef_union:
+    begin: "((?<!\\w)typedef(?!\\w))\\s*(?=(?<!\\w)union(?!\\w))"
+    beginCaptures:
+      '1':
+        name: keyword.other.typedef.cpp
+    end: "(?<=;)"
+    patterns:
+    - name: meta.block.union.cpp
+      begin: "((((?<!\\w)union(?!\\w))(?:(?:\\s+|((?:(?:(?:\\[\\[.*?\\]\\]|__attribute(?:__)?\\(\\(.*?\\)\\))|__declspec\\(.*?\\))|alignas\\(.*?\\))(?!\\))))|(?={))(?:((?:(?:(?:\\[\\[.*?\\]\\]|__attribute(?:__)?\\(\\(.*?\\)\\))|__declspec\\(.*?\\))|alignas\\(.*?\\))(?!\\))))?\\s*((?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F]))(?:(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F])))*(?!\\w))?(?:\\s+(final)\\s*)?(?:\\s*(:)((?:\\s*(?:,)?\\s*(?:(?:private|protected|public))?\\s*(?:\\s*(?:,)?\\s*(?!(?:private|protected|public))(?-mix:(?:\\s*(?<!\\w)(?=\\w)(?!(?:not|compl|sizeof|new|delete|not_eq|bitand|xor|bitor|and|or|throw|and_eq|xor_eq|or_eq|alignof|alignas|typeid|noexcept|static_cast|dynamic_cast|const_cast|reinterpret_cast|while|for|do|if|else|goto|switch|try|catch|return|break|case|continue|default|NULL|true|false|nullptr|const|static|volatile|register|restrict|extern|inline|constexpr|mutable|friend|explicit|virtual|final|override|volatile|const|noexcept|constexpr|mutable|constexpr|consteval|private|protected|public|if|elif|else|endif|ifdef|ifndef|define|undef|include|line|error|warning|pragma|_Pragma|defined|__has_include|__has_cpp_attribute|this|template|namespace|using|operator|typedef|decltype|typename|asm|__asm__|concept|requires|export|thread_local|atomic_cancel|atomic_commit|atomic_noexcept|co_await|co_return|co_yield|import|module|reflexpr|synchronized|audit|axiom|transaction_safe|transaction_safe_dynamic)(?![\\w])\\s*)(?:(?:(?:(?:(?:\\[\\[.*?\\]\\]|__attribute(?:__)?\\(\\(.*?\\)\\))|__declspec\\(.*?\\))|alignas\\(.*?\\))(?!\\))))?\\s*(?:(?:(?:short|signed|unsigned|long)|(?:class|struct|union|enum))\\s+)*(?:(?:(?:(?:(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F]))(?:(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F])))*\\s*(?:(?-mix:(?:(?<!<)<(?!<)(?:[\\s<>:,\\w])*>\\s*)))?::)*\\s*)(?:(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F]))(?:(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F])))*)\\s*(?:(?:(?<!<)<(?!<)(?:[\\s<>:,\\w])*>\\s*))?(?:::)))?\\s*(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F]))(?:(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F])))*(?:(?-mix:(?:(?<!<)<(?!<)(?:[\\s<>:,\\w])*>\\s*)))?(?![\\w<:.]))))+)*))?))"
+      beginCaptures:
+        '1':
+          name: meta.head.union.cpp
+        '3':
+          name: storage.type.$3.cpp
+        '4':
+          patterns:
+          - include: "#attributes_context"
+          - include: "#number_literal"
+        '5':
+          patterns:
+          - include: "#attributes_context"
+          - include: "#number_literal"
+        '6':
+          name: entity.name.type.$3.cpp
+        '7':
+          name: storage.type.modifier.final.cpp
+        '8':
+          name: colon.cpp punctuation.separator.inhertance.cpp
+        '9':
+          patterns:
+          - include: "#inhertance_context"
+      end: "(?:(?:(?<=})\\s*(;)|(;))|(?=[;>\\[\\]=]))"
+      endCaptures:
+        '1':
+          name: punctuation.terminator.statement.cpp
+        '2':
+          name: punctuation.terminator.statement.cpp
+      patterns:
+      - name: meta.head.union.cpp
+        begin: "\\G ?"
+        end: "((?:\\{|(?=;)))"
+        endCaptures:
+          '1':
+            name: punctuation.section.block.begin.bracket.curly.union.cpp
+        patterns:
+        - include: "#preprocessor_context"
+        - include: "#inhertance_context"
+        - include: "#template_call_range"
+        - include: "#comments_context"
+      - name: meta.body.union.cpp
+        begin: "(?<=\\{)"
+        end: "(\\})"
+        endCaptures:
+          '1':
+            name: punctuation.section.block.end.bracket.curly.union.cpp
+        patterns:
+        - include: "#function_pointer"
+        - include: "#constructor_context"
+        - include: "$base"
+      - name: meta.tail.union.cpp
+        begin: "(?<=})[\\s\\n]*"
+        end: "[\\s\\n]*(?=;)"
+        patterns:
+        - match: "(?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F]))(?:(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F])))*(?!\\w)"
+          name: entity.name.type.alias.cpp
   hacky_fix_for_stray_directive:
     match: "(?<!\\w)#(?:endif|else|elif)(?!\\w)"
     name: keyword.control.directive.$0.cpp
@@ -1762,6 +1957,9 @@
     - include: "#using_namespace"
     - include: "#type_alias"
     - include: "#namespace_block"
+    - include: "#typedef_class"
+    - include: "#typedef_struct"
+    - include: "#typedef_union"
     - include: "#class_block"
     - include: "#struct_block"
     - include: "#union_block"

--- a/test/fixtures/features/typedef_alias.cpp
+++ b/test/fixtures/features/typedef_alias.cpp
@@ -9,3 +9,6 @@ typedef class bar {
 typedef union foobar {
 
 } foobar;
+typedef struct _OVERLAPPED {
+
+} OVERLAPPED, *LPOVERLAPPED;

--- a/test/fixtures/features/typedef_alias.cpp
+++ b/test/fixtures/features/typedef_alias.cpp
@@ -1,0 +1,11 @@
+typedef struct foo {
+
+} foo;
+
+typedef class bar {
+
+} bar;
+
+typedef union foobar {
+
+} foobar;

--- a/test/specs/features/typedef_alias.cpp.yaml
+++ b/test/specs/features/typedef_alias.cpp.yaml
@@ -86,3 +86,43 @@
 - source: ;
   scopes:
     - punctuation.terminator.statement.cpp
+  scopesEnd:
+    - meta.block.union.cpp
+- source: typedef
+  scopes:
+    - keyword.other.typedef.cpp
+- source: struct
+  scopesBegin:
+    - meta.block.struct.cpp
+    - meta.head.struct.cpp
+  scopes:
+    - storage.type.struct.cpp
+- source: _OVERLAPPED
+  scopes:
+    - entity.name.type.struct.cpp
+- source: '{'
+  scopes:
+    - punctuation.section.block.begin.bracket.curly.struct.cpp
+  scopesEnd:
+    - meta.head.struct.cpp
+- source: '}'
+  scopes:
+    - meta.body.struct.cpp
+    - punctuation.section.block.end.bracket.curly.struct.cpp
+- source: OVERLAPPED
+  scopesBegin:
+    - meta.tail.struct.cpp
+  scopes:
+    - entity.name.type.alias.cpp
+- source: ','
+- source: '*'
+  scopes:
+    - storage.modifier.pointer.cpp
+- source: LPOVERLAPPED
+  scopes:
+    - entity.name.type.alias.cpp
+  scopesEnd:
+    - meta.tail.struct.cpp
+- source: ;
+  scopes:
+    - punctuation.terminator.statement.cpp

--- a/test/specs/features/typedef_alias.cpp.yaml
+++ b/test/specs/features/typedef_alias.cpp.yaml
@@ -1,0 +1,88 @@
+- source: typedef
+  scopes:
+    - keyword.other.typedef.cpp
+- source: struct
+  scopesBegin:
+    - meta.block.struct.cpp
+    - meta.head.struct.cpp
+  scopes:
+    - storage.type.struct.cpp
+- source: foo
+  scopes:
+    - entity.name.type.struct.cpp
+- source: '{'
+  scopes:
+    - punctuation.section.block.begin.bracket.curly.struct.cpp
+  scopesEnd:
+    - meta.head.struct.cpp
+- source: '}'
+  scopes:
+    - meta.body.struct.cpp
+    - punctuation.section.block.end.bracket.curly.struct.cpp
+- source: foo
+  scopes:
+    - meta.tail.struct.cpp
+    - entity.name.type.alias.cpp
+- source: ;
+  scopes:
+    - punctuation.terminator.statement.cpp
+  scopesEnd:
+    - meta.block.struct.cpp
+- source: typedef
+  scopes:
+    - keyword.other.typedef.cpp
+- source: class
+  scopesBegin:
+    - meta.block.class.cpp
+    - meta.head.class.cpp
+  scopes:
+    - storage.type.class.cpp
+- source: bar
+  scopes:
+    - entity.name.type.class.cpp
+- source: '{'
+  scopes:
+    - punctuation.section.block.begin.bracket.curly.class.cpp
+  scopesEnd:
+    - meta.head.class.cpp
+- source: '}'
+  scopes:
+    - meta.body.class.cpp
+    - punctuation.section.block.end.bracket.curly.class.cpp
+- source: bar
+  scopes:
+    - meta.tail.class.cpp
+    - entity.name.type.alias.cpp
+- source: ;
+  scopes:
+    - punctuation.terminator.statement.cpp
+  scopesEnd:
+    - meta.block.class.cpp
+- source: typedef
+  scopes:
+    - keyword.other.typedef.cpp
+- source: union
+  scopesBegin:
+    - meta.block.union.cpp
+    - meta.head.union.cpp
+  scopes:
+    - storage.type.union.cpp
+- source: foobar
+  scopes:
+    - entity.name.type.union.cpp
+- source: '{'
+  scopes:
+    - punctuation.section.block.begin.bracket.curly.union.cpp
+  scopesEnd:
+    - meta.head.union.cpp
+- source: '}'
+  scopes:
+    - meta.body.union.cpp
+    - punctuation.section.block.end.bracket.curly.union.cpp
+- source: foobar
+  scopes:
+    - meta.tail.union.cpp
+    - entity.name.type.alias.cpp
+- source: ;
+  scopes:
+    - punctuation.terminator.statement.cpp

--- a/test/src/generateSpec.js
+++ b/test/src/generateSpec.js
@@ -1,5 +1,5 @@
 const getTokens = require("./getTokens");
-const registry = require("./registry");
+const registry = require("./registry").default;
 const _ = require("lodash");
 
 /**


### PR DESCRIPTION
![Screenshot from 2019-05-21 19-19-27](https://user-images.githubusercontent.com/714007/58142810-600e4100-7bfd-11e9-8cd7-77154703fcc7.png)
if typedef is followed by `/struct|class|union/` then the declarators after it are markes as type aliases.

This is a part of #138