### PR TITLE
add linter

### DIFF
--- a/lint/index.js
+++ b/lint/index.js
@@ -17,7 +17,10 @@ const fs = require("fs");
  * }} TextMateRule
  */
 
-const linters = [require("./linters/unresolved")];
+const linters = [
+    require("./linters/unresolved"),
+    require("./linters/spell-check")
+];
 
 const grammar = JSON.parse(fs.readFileSync(process.argv[2]).toString());
 /**

--- a/lint/index.js
+++ b/lint/index.js
@@ -1,0 +1,85 @@
+const fs = require("fs");
+/**
+ * @typedef {{
+ *      match?: string
+ *      begin?: string
+ *      end?: string
+ *      while?: string
+ *      captures?: {[index: string]: TextMateRule}
+ *      beginCaptures?: {[index: string]: TextMateRule}
+ *      endCaptures?: {[index: string]: TextMateRule}
+ *      whileCaptures?: {[index: string]: TextMateRule}
+ *      name?: string
+ *      contentName?: string
+ *      includes?: string
+ *      patterns?: TextMateRule[]
+ *      repositoryName?: string
+ * }} TextMateRule
+ */
+
+const linters = [require("./linters/unresolved")];
+
+const grammar = JSON.parse(fs.readFileSync(process.argv[2]).toString());
+/**
+ * @type {TextMateRule[]}
+ */
+let stack = [];
+/**
+ * @type {TextMateRule[]}
+ */
+let repeat = [];
+for (const rule of grammar.patterns) {
+    stack.push(rule);
+}
+for (const rule of Object.keys(grammar.repository)) {
+    let r2 = grammar.repository[rule];
+    r2.repositoryName = "#" + rule;
+    stack.push(r2);
+}
+
+while (stack.length != 0) {
+    const rule = stack.pop();
+    repeat.push(rule);
+    for (const linter of linters) {
+        if (linter.firstPass) {
+            linter.firstPass(rule);
+        }
+    }
+    if (rule.patterns) {
+        for (const r2 of rule.patterns) {
+            stack.push(r2);
+        }
+    }
+    const processCaptures = key => {
+        if (rule[key]) {
+            for (const r2Key of Object.keys(rule[key])) {
+                let r2 = rule[key][r2Key];
+                r2.repositoryName = rule.repositoryName
+                    ? rule.repositoryName + "#" + key + r2Key
+                    : undefined;
+                stack.push(r2);
+            }
+        }
+    };
+    processCaptures("captures");
+    processCaptures("beginCaptures");
+    processCaptures("endCaptures");
+    processCaptures("whileCaptures");
+}
+for (const rule of repeat) {
+    for (const linter of linters) {
+        if (linter.secondPass) {
+            linter.secondPass(rule);
+        }
+    }
+}
+console.log();
+const result = linters.reduce(
+    (result, linter) => (linter.finalReport() ? result : false),
+    true
+);
+console.log(
+    "linting for %s: %s",
+    process.argv[2],
+    result ? "passed" : "failed"
+);

--- a/lint/linters/spell-check.js
+++ b/lint/linters/spell-check.js
@@ -76,7 +76,7 @@ class Spellcheck {
         return !spell.correct(name);
     }
     reportError(rule, word) {
-        let message = word + " is not spelled correctly.";
+        let message = word + " is not spelled correctly. ";
         if (rule.repositoryName) {
             message += "Rule is " + rule.repositoryName;
         } else {

--- a/lint/linters/spell-check.js
+++ b/lint/linters/spell-check.js
@@ -1,0 +1,108 @@
+var path = require("path");
+var baseDict = require.resolve("dictionary-en-us");
+const fs = require("fs");
+const nspell = require("nspell");
+const _ = require("lodash");
+const util = require("util");
+const chalk = require("chalk");
+
+/**
+ * @type {nspell.NSpell}
+ */
+let spell = nspell(
+    fs.readFileSync(path.join(baseDict, "..", "index.aff"), "utf-8"),
+    fs.readFileSync(path.join(baseDict, "..", "index.dic"), "utf-8")
+);
+[
+    "accessor",
+    "alignas",
+    "alignof",
+    "bitwise",
+    "c",
+    "cpp",
+    "decltype",
+    "dereference",
+    "destructor",
+    "elif",
+    "enum",
+    "enummember",
+    "extern",
+    "gt",
+    "initializer",
+    "lt",
+    "namespace",
+    "overloadee",
+    "parens",
+    "posix",
+    "pragma",
+    "preprocessor",
+    "pthread",
+    "qualified_type",
+    "readwrite",
+    "sizeof",
+    "static_assert",
+    "stdint",
+    "struct",
+    "sys",
+    "toc",
+    "typedef",
+    "typeid",
+    "typename",
+    "undef",
+    "vararg",
+    "whitespace"
+].forEach(word => spell.add(word));
+
+class Spellcheck {
+    constructor() {
+        this.messages = [];
+        this.doSpellcheck = this.doSpellcheck.bind(this);
+    }
+    doSpellcheck(name) {
+        if (name.includes(" ")) {
+            return _.some(name.split(" ").map(this.doSpellcheck));
+        }
+        if (name.includes(".")) {
+            return _.some(name.split(".").map(this.doSpellcheck));
+        }
+        if (name.includes("-")) {
+            return _.some(name.split("-").map(this.doSpellcheck));
+        }
+        // remove like at ebd of words "wordlike" => "word"
+        name = name.replace(/like$/, "");
+        if (/^\$\d+$/.test(name)) return false;
+        if (!spell) return false;
+        //console.log(name, spell.correct(name));
+        return !spell.correct(name);
+    }
+    reportError(rule, word) {
+        let message = word + " is not spelled correctly.";
+        if (rule.repositoryName) {
+            message += "Rule is " + rule.repositoryName;
+        } else {
+            message += "Rule is " + util.inspect(rule, false, 1, false);
+        }
+        this.messages.push(message);
+    }
+    firstPass(rule) {
+        if (rule.name) {
+            if (this.doSpellcheck(rule.name)) {
+                this.reportError(rule, rule.name);
+            }
+        }
+        if (rule.contentName) {
+            if (this.doSpellcheck(rule.contentName)) {
+                this.reportError(rule, rule.contentName);
+            }
+        }
+    }
+
+    finalReport() {
+        for (const message of this.messages) {
+            console.warn(chalk.yellowBright("[Spellcheck]  ", message));
+        }
+        return this.messages.length == 0;
+    }
+}
+
+module.exports = new Spellcheck();

--- a/lint/linters/unresolved.js
+++ b/lint/linters/unresolved.js
@@ -58,16 +58,18 @@ class Unresolved {
         for (const name of this.unresolved) {
             console.warn(
                 chalk.redBright(
-                    "[Unresolved]  %s is referenced but could not be found",
-                    name
+                    "[Unresolved]  ",
+                    name,
+                    "is referenced but could not be found"
                 )
             );
         }
         for (const name of this.unused) {
             console.warn(
                 chalk.yellowBright(
-                    "[Unresolved]  %s is named but is not used",
-                    name
+                    "[Unresolved]  ",
+                    name,
+                    "is named but is not used"
                 )
             );
         }

--- a/lint/linters/unresolved.js
+++ b/lint/linters/unresolved.js
@@ -1,0 +1,79 @@
+const chalk = require("chalk");
+
+class Unresolved {
+    constructor() {
+        this.unused = [];
+        this.unresolved = [];
+        this.resolved = ["$base", "$self"];
+    }
+    recordIncludes(rule) {
+        if (this.unused.includes(rule.include)) {
+            this.unused.splice(this.unused.indexOf(rule.include), 1);
+        }
+        if (this.resolved.includes(rule.include)) {
+            return;
+        }
+        if (!this.unresolved.includes(rule.include)) {
+            this.unresolved.push(rule.include);
+        }
+    }
+    recordRule(rule) {
+        // ignore nested rules
+        if (rule.repositoryName.lastIndexOf("#") > 0) {
+            return;
+        }
+        if (this.unresolved.includes(rule.repositoryName)) {
+            this.unresolved.splice(
+                this.unresolved.indexOf(rule.repositoryName),
+                1
+            );
+            this.resolved.push(rule.repositoryName);
+            return;
+        }
+        if (this.resolved.includes(rule.repositoryName)) {
+            return;
+        }
+        if (!this.unused.includes(rule.repositoryName)) {
+            this.unused.push(rule.repositoryName);
+        }
+    }
+    /**
+     * @param {TextMateRule} rule
+     */
+    firstPass(rule) {
+        if (rule.include) {
+            this.recordIncludes(rule);
+            return;
+        }
+        if (rule.repositoryName) {
+            this.recordRule(rule);
+        }
+    }
+    secondPass(rule) {
+        if (rule.repositoryName) {
+            this.recordRule(rule);
+        }
+    }
+    finalReport() {
+        for (const name of this.unresolved) {
+            console.warn(
+                chalk.redBright(
+                    "[Unresolved]  %s is referenced but could not be found",
+                    name
+                )
+            );
+        }
+        for (const name of this.unused) {
+            console.warn(
+                chalk.yellowBright(
+                    "[Unresolved]  %s is named but is not used",
+                    name
+                )
+            );
+        }
+        console.log();
+        return this.unresolved.length == 0;
+    }
+}
+
+module.exports = new Unresolved();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "better-cpp-syntax",
-    "version": "1.8.16",
+    "version": "1.9.4",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -136,6 +136,12 @@
             "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
             "dev": true
         },
+        "dictionary-en-us": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/dictionary-en-us/-/dictionary-en-us-2.1.1.tgz",
+            "integrity": "sha512-3182Q3ede8TEm6FthZ2u8FppaayB+D43wy5cnOSweZwg9vSmmUCjCA3zxmMpZLw0nIAILGLR0j+06o2l9aaCzA==",
+            "dev": true
+        },
         "emoji-regex": {
             "version": "7.0.3",
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
@@ -248,6 +254,12 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
             "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
+            "dev": true
+        },
+        "is-buffer": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
+            "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw==",
             "dev": true
         },
         "is-fullwidth-code-point": {
@@ -384,6 +396,15 @@
             "dev": true,
             "requires": {
                 "path-key": "^2.0.0"
+            }
+        },
+        "nspell": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/nspell/-/nspell-2.1.2.tgz",
+            "integrity": "sha512-j79L4A5aJSiswMUJ/6BW8+7ytgBUVce5BJX6xq8LtvKQpU96CMB340/yMeREH9U+gB/8dk4ctTn62DLiPMAXsA==",
+            "dev": true,
+            "requires": {
+                "is-buffer": "^2.0.0"
             }
         },
         "number-is-nan": {

--- a/package.json
+++ b/package.json
@@ -48,11 +48,13 @@
     },
     "devDependencies": {
         "chalk": "^2.4.2",
+        "dictionary-en-us": "^2.1.1",
         "glob": "^7.1.3",
         "js-yaml": "^3.13.1",
         "json-source-map": "^0.4.0",
         "json-stable-stringify": "^1.0.1",
         "lodash": "^4.17.11",
+        "nspell": "^2.1.2",
         "oniguruma": "^7.1.0",
         "prettyjson": "^1.2.1",
         "vscode-textmate": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
     "version": "1.9.4",
     "scripts": {
         "build": "ruby cpp/generate.rb && ruby c/generate.rb",
+        "prelint": "npm run build",
+        "lint": "node lint/index.js syntaxes/c.tmLanguage.json && node lint/index.js syntaxes/cpp.tmLanguage.json",
         "pretest": "npm run build",
         "test": "node test/src/commands/test.js",
         "cov": "npm test -- --coverage",


### PR DESCRIPTION
This adds a simple 2 pass linter over the produced grammar.
The linter is given an entire textmate rule and is allowed to keep context.
This is used in this commit to check for unresolved and unused names.

Linters could be added to check scope names for spelling mistakes, or consistency.
There could be a linter to ensure `null` is never a key as that breaks vscode-textmate.

Fixes: #125

Sample Output:
![Screenshot from 2019-05-25 00-57-02](https://user-images.githubusercontent.com/714007/58366500-0cfbee80-7e88-11e9-8358-673e12de8ad9.png)

