### PR TITLE
Add destructor pattern

### DIFF
--- a/language_tags/cpp.txt
+++ b/language_tags/cpp.txt
@@ -30,6 +30,7 @@ entity.name.function.definition.cpp
 entity.name.function.destructor.cpp
 entity.name.function.member.cpp
 entity.name.function.preprocessor.cpp
+entity.name.function.special.destructor.cpp
 entity.name.namespace.alias.cpp
 entity.name.namespace.cpp
 entity.name.operator.overloadee.cpp
@@ -406,7 +407,6 @@ meta.function.definition.parameters.cpp
 meta.function.definition.parameters.lambda.cpp
 meta.function.definition.parameters.operator-overload.cpp
 meta.function.destructor.cpp
-meta.function.destructor.prototype.cpp
 meta.head.class.cpp
 meta.head.enum.cpp
 meta.head.extern.cpp

--- a/scripts/generate.rb
+++ b/scripts/generate.rb
@@ -6,6 +6,6 @@ for each_dir in Dir["source/languages/**"]
     exit_code = Integer($?)
     if exit_code != 0
         puts "\n\nGenerating the syntax for #{File.basename(each_dir)} failed: #{exit_code}"
-        exit(exit_code)
+        exit(false)
     end
 end

--- a/scripts/lint.rb
+++ b/scripts/lint.rb
@@ -6,6 +6,6 @@ for each_file in Dir["syntaxes/**.tmLanguage.json"]
     Process.wait(Process.spawn("node", "lint/index.js", each_file))
     exit_code = Integer($?)
     if exit_code != 0
-        exit(exit_code)
+        exit(false)
     end
 end

--- a/syntaxes/cpp.tmLanguage.json
+++ b/syntaxes/cpp.tmLanguage.json
@@ -200,9 +200,6 @@
           "include": "#destructor"
         },
         {
-          "include": "#destructor_prototype"
-        },
-        {
           "include": "#lambdas"
         },
         {
@@ -404,9 +401,6 @@
         },
         {
           "include": "#destructor"
-        },
-        {
-          "include": "#destructor_prototype"
         },
         {
           "include": "#lambdas"
@@ -5119,50 +5113,19 @@
       "name": "storage.modifier.cpp"
     },
     "destructor": {
-      "name": "meta.function.destructor.cpp",
-      "begin": "(?x)\n(?:\n  ^ |                  # beginning of line\n  (?:(?<!else|new|=))  # or word + space before name\n)\n((?:[A-Za-z_][A-Za-z0-9_]*::)*+~[A-Za-z_][A-Za-z0-9_]*) # actual name\n\\s*(\\()              # opening bracket",
-      "beginCaptures": {
+      "match": "(?<![a-zA-Z0-9_])((?:((?>(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F]))(?:(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F])))*))\\s*::\\s*~\\2|~(?>(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F]))(?:(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F])))*)))\\s*(\\()\\s*(\\))",
+      "captures": {
         "1": {
-          "name": "entity.name.function.destructor.cpp"
+          "name": "entity.name.function.destructor.cpp entity.name.function.special.destructor.cpp"
         },
-        "2": {
+        "3": {
           "name": "punctuation.definition.parameters.begin.destructor.cpp"
-        }
-      },
-      "end": "(?-mix:\\))",
-      "endCaptures": {
-        "0": {
+        },
+        "4": {
           "name": "punctuation.definition.parameters.end.destructor.cpp"
         }
       },
-      "patterns": [
-        {
-          "include": "#root_context"
-        }
-      ]
-    },
-    "destructor_prototype": {
-      "name": "meta.function.destructor.prototype.cpp",
-      "begin": "(?x)\n(?:\n  ^ |                  # beginning of line\n  (?:(?<!else|new|=))  # or word + space before name\n)\n((?:[A-Za-z_][A-Za-z0-9_]*::)*+~[A-Za-z_][A-Za-z0-9_]*) # actual name\n\\s*(\\()              # opening bracket",
-      "beginCaptures": {
-        "1": {
-          "name": "entity.name.function.cpp"
-        },
-        "2": {
-          "name": "punctuation.definition.parameters.begin.cpp"
-        }
-      },
-      "end": "(?-mix:\\))",
-      "endCaptures": {
-        "0": {
-          "name": "punctuation.definition.parameters.end.cpp"
-        }
-      },
-      "patterns": [
-        {
-          "include": "#root_context"
-        }
-      ]
+      "name": "meta.function.destructor.cpp"
     },
     "meta_preprocessor_macro": {
       "name": "meta.preprocessor.macro.cpp",

--- a/syntaxes/cpp.tmLanguage.yaml
+++ b/syntaxes/cpp.tmLanguage.yaml
@@ -109,7 +109,6 @@
     - include: "#template_definition"
     - include: "#misc_storage_modifiers_1"
     - include: "#destructor"
-    - include: "#destructor_prototype"
     - include: "#lambdas"
     - include: "#preprocessor_context"
     - include: "#comments_context"
@@ -179,7 +178,6 @@
     - include: "#template_definition"
     - include: "#misc_storage_modifiers_1"
     - include: "#destructor"
-    - include: "#destructor_prototype"
     - include: "#lambdas"
     - include: "#preprocessor_context"
     - include: "#comments_context"
@@ -2642,47 +2640,15 @@
     match: !ruby/regexp /\b(const|extern|register|restrict|static|volatile|inline)\b/
     name: storage.modifier.cpp
   destructor:
-    name: meta.function.destructor.cpp
-    begin: |-
-      (?x)
-      (?:
-        ^ |                  # beginning of line
-        (?:(?<!else|new|=))  # or word + space before name
-      )
-      ((?:[A-Za-z_][A-Za-z0-9_]*::)*+~[A-Za-z_][A-Za-z0-9_]*) # actual name
-      \s*(\()              # opening bracket
-    beginCaptures:
+    match: "(?<![a-zA-Z0-9_])((?:((?>(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F]))(?:(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F])))*))\\s*::\\s*~\\2|~(?>(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F]))(?:(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U000[0-9a-fA-F])))*)))\\s*(\\()\\s*(\\))"
+    captures:
       '1':
-        name: entity.name.function.destructor.cpp
-      '2':
+        name: entity.name.function.destructor.cpp entity.name.function.special.destructor.cpp
+      '3':
         name: punctuation.definition.parameters.begin.destructor.cpp
-    end: !ruby/regexp /\)/
-    endCaptures:
-      '0':
+      '4':
         name: punctuation.definition.parameters.end.destructor.cpp
-    patterns:
-    - include: "#root_context"
-  destructor_prototype:
-    name: meta.function.destructor.prototype.cpp
-    begin: |-
-      (?x)
-      (?:
-        ^ |                  # beginning of line
-        (?:(?<!else|new|=))  # or word + space before name
-      )
-      ((?:[A-Za-z_][A-Za-z0-9_]*::)*+~[A-Za-z_][A-Za-z0-9_]*) # actual name
-      \s*(\()              # opening bracket
-    beginCaptures:
-      '1':
-        name: entity.name.function.cpp
-      '2':
-        name: punctuation.definition.parameters.begin.cpp
-    end: !ruby/regexp /\)/
-    endCaptures:
-      '0':
-        name: punctuation.definition.parameters.end.cpp
-    patterns:
-    - include: "#root_context"
+    name: meta.function.destructor.cpp
   meta_preprocessor_macro:
     name: meta.preprocessor.macro.cpp
     begin: "(?x)\n^\\s* ((\\#)\\s*define) \\s+\t# define\n((?<id>(?-mix:[a-zA-Z_$][\\w$]*)))\t

--- a/test/fixtures/issues/080.cpp
+++ b/test/fixtures/issues/080.cpp
@@ -1,0 +1,5 @@
+class foo {
+    ~foo();
+};
+foo::~foo() {}
+foo::~bar() {}

--- a/test/specs/issues/080.cpp.yaml
+++ b/test/specs/issues/080.cpp.yaml
@@ -1,0 +1,96 @@
+- source: class
+  scopesBegin:
+    - source
+    - meta.block.class
+    - meta.head.class
+  scopes:
+    - storage.type.class
+- source: foo
+  scopes:
+    - entity.name.type.class
+- source: '{'
+  scopes:
+    - punctuation.section.block.begin.bracket.curly.class
+  scopesEnd:
+    - meta.head.class
+- source: ~foo
+  scopesBegin:
+    - meta.body.class
+    - meta.function.destructor
+  scopes:
+    - entity.name.function.destructor
+    - entity.name.function.special.destructor
+- source: (
+  scopes:
+    - punctuation.definition.parameters.begin.destructor
+- source: )
+  scopes:
+    - punctuation.definition.parameters.end.destructor
+  scopesEnd:
+    - meta.function.destructor
+- source: ;
+  scopes:
+    - punctuation.terminator.statement
+- source: '}'
+  scopes:
+    - punctuation.section.block.end.bracket.curly.class
+  scopesEnd:
+    - meta.body.class
+- source: ;
+  scopes:
+    - punctuation.terminator.statement
+  scopesEnd:
+    - meta.block.class
+- source: 'foo::~foo'
+  scopesBegin:
+    - meta.function.destructor
+  scopes:
+    - entity.name.function.destructor
+    - entity.name.function.special.destructor
+- source: (
+  scopes:
+    - punctuation.definition.parameters.begin.destructor
+- source: )
+  scopes:
+    - punctuation.definition.parameters.end.destructor
+  scopesEnd:
+    - meta.function.destructor
+- source: '{'
+  scopesBegin:
+    - meta.block
+  scopes:
+    - punctuation.section.block.begin.bracket.curly
+- source: '}'
+  scopes:
+    - punctuation.section.block.end.bracket.curly
+  scopesEnd:
+    - meta.block
+- source: foo
+  scopes:
+    - entity.name.scope-resolution
+- source: '::'
+  scopes:
+    - punctuation.separator.namespace.access
+    - punctuation.separator.scope-resolution
+- source: ~bar
+  scopesBegin:
+    - meta.function.destructor
+  scopes:
+    - entity.name.function.destructor
+    - entity.name.function.special.destructor
+- source: (
+  scopes:
+    - punctuation.definition.parameters.begin.destructor
+- source: )
+  scopes:
+    - punctuation.definition.parameters.end.destructor
+  scopesEnd:
+    - meta.function.destructor
+- source: '{'
+  scopesBegin:
+    - meta.block
+  scopes:
+    - punctuation.section.block.begin.bracket.curly
+- source: '}'
+  scopes:
+    - punctuation.section.block.end.bracket.curly

--- a/test/specs/vscode/misc.mm.yaml
+++ b/test/specs/vscode/misc.mm.yaml
@@ -18,6 +18,8 @@
   scopes:
     - entity.scope.name
 - source: '::'
+  scopes:
+    - punctuation.separator.namespace.access
   scopesEnd:
     - punctuation.separator.namespace.access
 - source: optional
@@ -560,6 +562,8 @@
   scopes:
     - entity.scope.name
 - source: '::'
+  scopes:
+    - punctuation.separator.namespace.access
   scopesEnd:
     - punctuation.separator.namespace.access
 - source: vector
@@ -752,6 +756,8 @@
   scopes:
     - entity.scope.name
 - source: '::'
+  scopes:
+    - punctuation.separator.namespace.access
   scopesEnd:
     - punctuation.separator.namespace.access
 - source: 'cout '
@@ -907,6 +913,8 @@
   scopes:
     - entity.scope.name
 - source: '::'
+  scopes:
+    - punctuation.separator.namespace.access
   scopesEnd:
     - punctuation.separator.namespace.access
 - source: 'cout '
@@ -1062,6 +1070,8 @@
   scopes:
     - entity.scope.name
 - source: '::'
+  scopes:
+    - punctuation.separator.namespace.access
   scopesEnd:
     - punctuation.separator.namespace.access
 - source: 'cout '

--- a/test/specs/vscode/misc001.cpp.yaml
+++ b/test/specs/vscode/misc001.cpp.yaml
@@ -298,6 +298,7 @@
     - meta.function.destructor
   scopes:
     - entity.name.function.destructor
+    - entity.name.function.special.destructor
 - source: (
   scopes:
     - punctuation.definition.parameters.begin.destructor

--- a/test/specs/vscode/misc004.m.yaml
+++ b/test/specs/vscode/misc004.m.yaml
@@ -79,17 +79,16 @@
 - source: end
   scopesEnd:
     - meta.interface-or-protocol
+    - storage.type
 - source: '@'
-  scopes:
+  scopesBegin:
     - meta.implementation
+    - storage.type
+  scopes:
     - punctuation.definition.storage.type
-  scopesEnd:
-    - meta.interface-or-protocol
 - source: implementation
-  scopes:
-    - meta.implementation
   scopesEnd:
-    - meta.interface-or-protocol
+    - meta.implementation
     - storage.type
 - source: ViewController
   scopesBegin:


### PR DESCRIPTION
destructors are not allowed to take parameters so a range is not needed.
destructor_proptype was an unneeded pattern.

prevents matching foo::~bar() as a single function name. Instead, its matched as a scope resolution and ~foo()

Part of #80

The generate script was made to just return false on error. See the commit message for why.