### PR TITLE
make source_wrapper never consume characters

### DIFF
--- a/source/languages/cpp/generate.rb
+++ b/source/languages/cpp/generate.rb
@@ -340,11 +340,11 @@ cpp_grammar = Grammar.new(
     cpp_grammar[:source_wrapper] = [
         PatternRange.new(
             # the first position
-            start_pattern: /^\s*/,
-            # the line with no newline after it
-            end_pattern: /\s*$/.lookAheadToAvoid(/\n/),
+            start_pattern: lookAheadFor(/^/),
+            # ensure end never matches
+            end_pattern: /not/.lookBehindFor(/possible/),
             tag_as: "source",
-            includes: [:root_context]
+            includes: [:root_context],
         ),
     ]
 

--- a/source/languages/cpp/generate.rb
+++ b/source/languages/cpp/generate.rb
@@ -337,11 +337,15 @@ cpp_grammar = Grammar.new(
 # 
 # source wrapper
 # 
+    # everthing is wrapped inside this context, and it should only be matched once
+    # this exists so that `source.cpp` will exist even inside of embedded files (like markdown)
     cpp_grammar[:source_wrapper] = [
         PatternRange.new(
             # the first position
             start_pattern: lookAheadFor(/^/),
             # ensure end never matches
+            # why? because textmate will keep looking until it hits the end of the file (which is the purpose of this wrapper)
+            # how? because the regex is trying to find "not" and then checks to see if "not" == "possible" (which can never happen)
             end_pattern: /not/.lookBehindFor(/possible/),
             tag_as: "source",
             includes: [:root_context],

--- a/syntaxes/cpp.tmLanguage.json
+++ b/syntaxes/cpp.tmLanguage.json
@@ -647,8 +647,8 @@
       "patterns": [
         {
           "name": "source.cpp",
-          "begin": "^\\s*",
-          "end": "\\s*$(?!\\n)",
+          "begin": "(?=^)",
+          "end": "not(?<=possible)",
           "patterns": [
             {
               "include": "#root_context"

--- a/syntaxes/cpp.tmLanguage.yaml
+++ b/syntaxes/cpp.tmLanguage.yaml
@@ -266,8 +266,8 @@
   source_wrapper:
     patterns:
     - name: source.cpp
-      begin: "^\\s*"
-      end: "\\s*$(?!\\n)"
+      begin: "(?=^)"
+      end: not(?<=possible)
       patterns:
       - include: "#root_context"
   number_literal:

--- a/test/fixtures/issues/222.cpp
+++ b/test/fixtures/issues/222.cpp
@@ -1,0 +1,2 @@
+ #define hello
+#define hello


### PR DESCRIPTION
When the source wrapper pattern consumes a character it makes patterns that match using the start anchor no longer work when that pattern is the first line. This PR modifies source_pattern to not consume any characters and provides an end pattern that is not possible to match. These two changes combined, ensure that the source wrapper matches every part of the document.

Fixes: #222