### PR TITLE
handle empty patterns when making report

### DIFF
--- a/test/source/report/onig_scanner.js
+++ b/test/source/report/onig_scanner.js
@@ -64,7 +64,9 @@ module.exports = class OnigScanner {
                 }
             }
         }
-        chosenResult.chosen = true;
+        if (chosenResult) {
+            chosenResult.chosen = true;
+        }
         //report all results
         for (const result of results) {
             this.recorder.record(

--- a/test/source/report/oniguruma_decorator.js
+++ b/test/source/report/oniguruma_decorator.js
@@ -43,6 +43,9 @@ module.exports = {
              * @param {string[]} patterns
              */
             createOnigScanner: patterns => {
+                if (patterns.length === 0) {
+                    return new OnigScanner(patterns, undefined);
+                }
                 // grab scopeName from first pattern
                 const scopeName = patterns[0].match(
                     /^\(\?#(source\..+):\d+\)/


### PR DESCRIPTION
The record/report feature of the tests would choke when the grammar has a rule with an empty `patterns` key. This PR fixes that