### PR TITLE
ensure a type always follows typename

### DIFF
--- a/source/languages/cpp/generate.rb
+++ b/source/languages/cpp/generate.rb
@@ -315,6 +315,7 @@ cpp_grammar = Grammar.new(
             :pthread_types,
             :posix_reserved_types,
             :decltype,
+            :typename,
         ]
 # 
 # Comments
@@ -959,6 +960,14 @@ cpp_grammar = Grammar.new(
             ).maybe(
                 array_brackets
             ).maybe(@spaces).then(@semicolon.or(/\n/)),
+    )
+    cpp_grammar[:typename] = newPattern(
+        should_fully_match: ["typename Alloc::select_on_container_copy_construction"],
+        should_not_partial_match: ["this_typename_is_valid"],
+        match: newPattern(
+            match: variableBounds[/typename/],
+            tag_as: "storage.modifier"
+        ).then(std_space).then(qualified_type)
     )
 #
 # Support

--- a/syntaxes/cpp.tmLanguage.json
+++ b/syntaxes/cpp.tmLanguage.json
@@ -362,6 +362,9 @@
         },
         {
           "include": "#decltype"
+        },
+        {
+          "include": "#typename"
         }
       ]
     },
@@ -2487,6 +2490,185 @@
         }
       },
       "name": "meta.declaration.type.alias.cpp"
+    },
+    "typename": {
+      "match": "((?<!\\w)typename(?!\\w))((?:(?:(?>\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+?|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))(\\s*+((?:(?:(?:\\[\\[.*?\\]\\]|__attribute(?:__)?\\(\\(.*?\\)\\))|__declspec\\(.*?\\))|alignas\\(.*?\\))(?!\\)))?((?:(?:(?>\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+?|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))(?:(?:(?:short|signed|unsigned|long)|(?:class|struct|union|enum))((?:(?:(?>\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+?|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))*(((?:::)?(?:(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*\\s*+(?:(?<!<)<(?!<)(?:[^<>]*|[^>]*+<[^>]*+>)++>\\s*)?::)*\\s*+)((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)\\s*+((?<!<)<(?!<)(?:[^<>]*|[^>]*+<[^>]*+>)++>\\s*)?(::))?((?:(?:(?>\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+?|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))(?!(?:not|compl|sizeof|new|delete|not_eq|bitand|xor|bitor|and|or|throw|and_eq|xor_eq|or_eq|alignof|alignas|typeid|noexcept|noexcept|static_cast|dynamic_cast|const_cast|reinterpret_cast|while|for|do|if|else|goto|switch|try|catch|return|break|case|continue|default|NULL|true|false|nullptr|const|static|volatile|register|restrict|extern|inline|constexpr|mutable|friend|explicit|virtual|final|override|volatile|const|noexcept|constexpr|mutable|constexpr|consteval|private|protected|public|if|elif|else|endif|ifdef|ifndef|define|undef|include|line|error|warning|pragma|_Pragma|defined|__has_include|__has_cpp_attribute|this|template|namespace|using|operator|typedef|decltype|typename|asm|__asm__|concept|requires|export|thread_local|atomic_cancel|atomic_commit|atomic_noexcept|co_await|co_return|co_yield|import|module|reflexpr|synchronized|audit|axiom|transaction_safe|transaction_safe_dynamic)\\b)((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)\\b(?:(?<!<)<(?!<)(?:[^<>]*|[^>]*+<[^>]*+>)++>\\s*)?(?![\\w<:.]))",
+      "captures": {
+        "1": {
+          "name": "storage.modifier.cpp"
+        },
+        "2": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "3": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "4": {
+          "name": "comment.block.cpp"
+        },
+        "5": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "6": {
+          "name": "meta.qualified_type.cpp",
+          "patterns": [
+            {
+              "match": "(?:class|struct|union|enum)",
+              "name": "storage.type.$0.cpp"
+            },
+            {
+              "include": "#attributes_context"
+            },
+            {
+              "include": "#function_type"
+            },
+            {
+              "include": "#storage_types"
+            },
+            {
+              "include": "#number_literal"
+            },
+            {
+              "include": "#string_context_c"
+            },
+            {
+              "include": "#comma"
+            },
+            {
+              "include": "#scope_resolution_inner_generated"
+            },
+            {
+              "include": "#template_call_range"
+            },
+            {
+              "match": "(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*",
+              "name": "entity.name.type.cpp"
+            }
+          ]
+        },
+        "7": {
+          "patterns": [
+            {
+              "include": "#attributes_context"
+            },
+            {
+              "include": "#number_literal"
+            }
+          ]
+        },
+        "8": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "9": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "10": {
+          "name": "comment.block.cpp"
+        },
+        "11": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "12": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "13": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "14": {
+          "name": "comment.block.cpp"
+        },
+        "15": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "17": {
+          "patterns": [
+            {
+              "include": "#scope_resolution_inner_generated"
+            }
+          ]
+        },
+        "18": {
+          "name": "entity.name.scope-resolution.cpp"
+        },
+        "19": {
+          "name": "meta.template.call.cpp",
+          "patterns": [
+            {
+              "include": "#template_call_range"
+            }
+          ]
+        },
+        "20": {
+          "name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.cpp"
+        },
+        "21": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "22": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "23": {
+          "name": "comment.block.cpp"
+        },
+        "24": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "25": {
+          "name": "entity.name.type.cpp"
+        }
+      }
     },
     "predefined_macros": {
       "patterns": [

--- a/syntaxes/cpp.tmLanguage.yaml
+++ b/syntaxes/cpp.tmLanguage.yaml
@@ -143,6 +143,7 @@ repository:
     - include: "#pthread_types"
     - include: "#posix_reserved_types"
     - include: "#decltype"
+    - include: "#typename"
   block_comment:
     name: comment.block.cpp
     begin: "\\s*+(\\/\\*)"
@@ -1299,6 +1300,95 @@ repository:
       '68':
         name: punctuation.terminator.statement.cpp
     name: meta.declaration.type.alias.cpp
+  typename:
+    match: "((?<!\\w)typename(?!\\w))((?:(?:(?>\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+?|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))(\\s*+((?:(?:(?:\\[\\[.*?\\]\\]|__attribute(?:__)?\\(\\(.*?\\)\\))|__declspec\\(.*?\\))|alignas\\(.*?\\))(?!\\)))?((?:(?:(?>\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+?|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))(?:(?:(?:short|signed|unsigned|long)|(?:class|struct|union|enum))((?:(?:(?>\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+?|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))*(((?:::)?(?:(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*\\s*+(?:(?<!<)<(?!<)(?:[^<>]*|[^>]*+<[^>]*+>)++>\\s*)?::)*\\s*+)((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)\\s*+((?<!<)<(?!<)(?:[^<>]*|[^>]*+<[^>]*+>)++>\\s*)?(::))?((?:(?:(?>\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+?|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))(?!(?:not|compl|sizeof|new|delete|not_eq|bitand|xor|bitor|and|or|throw|and_eq|xor_eq|or_eq|alignof|alignas|typeid|noexcept|noexcept|static_cast|dynamic_cast|const_cast|reinterpret_cast|while|for|do|if|else|goto|switch|try|catch|return|break|case|continue|default|NULL|true|false|nullptr|const|static|volatile|register|restrict|extern|inline|constexpr|mutable|friend|explicit|virtual|final|override|volatile|const|noexcept|constexpr|mutable|constexpr|consteval|private|protected|public|if|elif|else|endif|ifdef|ifndef|define|undef|include|line|error|warning|pragma|_Pragma|defined|__has_include|__has_cpp_attribute|this|template|namespace|using|operator|typedef|decltype|typename|asm|__asm__|concept|requires|export|thread_local|atomic_cancel|atomic_commit|atomic_noexcept|co_await|co_return|co_yield|import|module|reflexpr|synchronized|audit|axiom|transaction_safe|transaction_safe_dynamic)\\b)((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)\\b(?:(?<!<)<(?!<)(?:[^<>]*|[^>]*+<[^>]*+>)++>\\s*)?(?![\\w<:.]))"
+    captures:
+      '1':
+        name: storage.modifier.cpp
+      '2':
+        patterns:
+        - include: "#inline_comment"
+      '3':
+        name: comment.block.cpp punctuation.definition.comment.begin.cpp
+      '4':
+        name: comment.block.cpp
+      '5':
+        patterns:
+        - match: "\\*\\/"
+          name: comment.block.cpp punctuation.definition.comment.end.cpp
+        - match: "\\*"
+          name: comment.block.cpp
+      '6':
+        name: meta.qualified_type.cpp
+        patterns:
+        - match: "(?:class|struct|union|enum)"
+          name: storage.type.$0.cpp
+        - include: "#attributes_context"
+        - include: "#function_type"
+        - include: "#storage_types"
+        - include: "#number_literal"
+        - include: "#string_context_c"
+        - include: "#comma"
+        - include: "#scope_resolution_inner_generated"
+        - include: "#template_call_range"
+        - match: "(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*"
+          name: entity.name.type.cpp
+      '7':
+        patterns:
+        - include: "#attributes_context"
+        - include: "#number_literal"
+      '8':
+        patterns:
+        - include: "#inline_comment"
+      '9':
+        name: comment.block.cpp punctuation.definition.comment.begin.cpp
+      '10':
+        name: comment.block.cpp
+      '11':
+        patterns:
+        - match: "\\*\\/"
+          name: comment.block.cpp punctuation.definition.comment.end.cpp
+        - match: "\\*"
+          name: comment.block.cpp
+      '12':
+        patterns:
+        - include: "#inline_comment"
+      '13':
+        name: comment.block.cpp punctuation.definition.comment.begin.cpp
+      '14':
+        name: comment.block.cpp
+      '15':
+        patterns:
+        - match: "\\*\\/"
+          name: comment.block.cpp punctuation.definition.comment.end.cpp
+        - match: "\\*"
+          name: comment.block.cpp
+      '17':
+        patterns:
+        - include: "#scope_resolution_inner_generated"
+      '18':
+        name: entity.name.scope-resolution.cpp
+      '19':
+        name: meta.template.call.cpp
+        patterns:
+        - include: "#template_call_range"
+      '20':
+        name: punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.cpp
+      '21':
+        patterns:
+        - include: "#inline_comment"
+      '22':
+        name: comment.block.cpp punctuation.definition.comment.begin.cpp
+      '23':
+        name: comment.block.cpp
+      '24':
+        patterns:
+        - match: "\\*\\/"
+          name: comment.block.cpp punctuation.definition.comment.end.cpp
+        - match: "\\*"
+          name: comment.block.cpp
+      '25':
+        name: entity.name.type.cpp
   predefined_macros:
     patterns:
     - match: "\\b__cplusplus\\b"

--- a/test/specs/features/constructors.cpp.yaml
+++ b/test/specs/features/constructors.cpp.yaml
@@ -241,13 +241,24 @@
       punctuation.section.block.begin.bracket.curly.function.definition.special.member.destructor
   scopesEnd:
     - meta.head.function.definition.special.member.destructor
+- source: itng
+  scopesBegin:
+    - meta.body.function.definition.special.member.destructor
+  scopes:
+    - entity.name.function.call
+- source: (
+  scopes:
+    - punctuation.section.arguments.begin.bracket.round.function.call
+- source: )
+  scopes:
+    - punctuation.section.arguments.end.bracket.round.function.call
 - source: '}'
   scopes:
-    - meta.body.function.definition.special.member.destructor
     - >-
       punctuation.section.block.end.bracket.curly.function.definition.special.member.destructor
   scopesEnd:
     - meta.function.definition.special.member.destructor
+    - meta.body.function.definition.special.member.destructor
 - source: Thing4
   scopesBegin:
     - meta.function.definition.special.constructor

--- a/test/specs/issues/071.cpp.yaml
+++ b/test/specs/issues/071.cpp.yaml
@@ -128,17 +128,21 @@
     - punctuation.section.angle-brackets.begin.template.call
 - source: typename
   scopes:
-    - storage.type.user-defined
+    - storage.modifier
 - source: templated
+  scopesBegin:
+    - meta.qualified_type
   scopes:
-    - entity.name.scope-resolution.template.call
+    - entity.name.scope-resolution
 - source: '::'
   scopes:
     - punctuation.separator.namespace.access
-    - punctuation.separator.scope-resolution.template.call
+    - punctuation.separator.scope-resolution
 - source: type
   scopes:
-    - storage.type.user-defined
+    - entity.name.type
+  scopesEnd:
+    - meta.qualified_type
 - source: '*'
   scopes:
     - keyword.operator
@@ -241,17 +245,21 @@
     - punctuation.section.angle-brackets.begin.template.call
 - source: typename
   scopes:
-    - storage.type.user-defined
+    - storage.modifier
 - source: templated
+  scopesBegin:
+    - meta.qualified_type
   scopes:
-    - entity.name.scope-resolution.template.call
+    - entity.name.scope-resolution
 - source: '::'
   scopes:
     - punctuation.separator.namespace.access
-    - punctuation.separator.scope-resolution.template.call
+    - punctuation.separator.scope-resolution
 - source: type
   scopes:
-    - storage.type.user-defined
+    - entity.name.type
+  scopesEnd:
+    - meta.qualified_type
 - source: '*'
   scopes:
     - keyword.operator

--- a/test/specs/issues/082.cpp.yaml
+++ b/test/specs/issues/082.cpp.yaml
@@ -275,6 +275,8 @@
   scopes:
     - storage.modifier
 - source: allocatorT
+  scopesBegin:
+    - meta.qualified_type
   scopes:
     - entity.name.scope-resolution
 - source: '::'
@@ -282,8 +284,11 @@
     - punctuation.separator.namespace.access
     - punctuation.separator.scope-resolution
 - source: value_type
+  scopes:
+    - entity.name.type
   scopesEnd:
     - meta.arguments.operator.typeid
+    - meta.qualified_type
 - source: )
   scopes:
     - punctuation.section.arguments.end.bracket.round.operator.typeid
@@ -637,6 +642,8 @@
   scopes:
     - storage.modifier
 - source: allocatorT
+  scopesBegin:
+    - meta.qualified_type
   scopes:
     - entity.name.scope-resolution
 - source: '::'
@@ -644,8 +651,11 @@
     - punctuation.separator.namespace.access
     - punctuation.separator.scope-resolution
 - source: value_type
+  scopes:
+    - entity.name.type
   scopesEnd:
     - meta.arguments.operator.typeid
+    - meta.qualified_type
 - source: )
   scopes:
     - punctuation.section.arguments.end.bracket.round.operator.typeid

--- a/test/specs/vscode/example.cpp.yaml
+++ b/test/specs/vscode/example.cpp.yaml
@@ -6244,6 +6244,8 @@
   scopes:
     - storage.modifier
 - source: allocatorT
+  scopesBegin:
+    - meta.qualified_type
   scopes:
     - entity.name.scope-resolution
 - source: '::'
@@ -6251,8 +6253,11 @@
     - punctuation.separator.namespace.access
     - punctuation.separator.scope-resolution
 - source: value_type
+  scopes:
+    - entity.name.type
   scopesEnd:
     - meta.arguments.operator.typeid
+    - meta.qualified_type
 - source: )
   scopes:
     - punctuation.section.arguments.end.bracket.round.operator.typeid


### PR DESCRIPTION
The keyword `typename` signals that the next qualified identifier is a type.
That information is used in this PR to signal that a qualified_type follows `typename`.

This has minimal regression of tags. In templates preceding scopes have their scope changed from `entity.name.scope-resolution.template.call` to `entity.name.scope-resolution`. This should hopefully be resolved when templates are fixed.

This is part of #138.

State | Image
------|------
Before |  ![Screenshot from 2019-06-30 11-31-25](https://user-images.githubusercontent.com/714007/60400587-b5a60980-9b2a-11e9-997b-474d7822d3c0.png)
After | ![Screenshot from 2019-06-30 11-32-55](https://user-images.githubusercontent.com/714007/60400598-d3736e80-9b2a-11e9-9b43-19090f3e643b.png)


