### PR TITLE
Fix spec generator. update bad tests

### DIFF
--- a/test/source/generate_spec.js
+++ b/test/source/generate_spec.js
@@ -76,15 +76,19 @@ module.exports = async function generateSpec(path, fixture) {
             }
             if (scopesEnd.length) {
                 object.scopesEnd = scopesEnd;
-                object.scopes = _.difference(object.scopes, scopesEnd);
                 for (let scope of scopesEnd.slice().reverse()) {
                     if (scope === scopeStack[scopeStack.length - 1]) {
                         scopeStack.pop();
                     }
                 }
+                let nonLocalScopes = [...scopeStack, ...scopesEnd];
+                object.scopes = [
+                    ...scopeStack,
+                    ...object.scopes.slice(nonLocalScopes.length)
+                ];
             }
         }
-        object.scopes = _.difference(object.scopes, scopeStack);
+        object.scopes = object.scopes.slice(scopeStack.length);
         if (object.scopes.length === 0) {
             object.scopes = undefined;
         }

--- a/test/specs/issues/134.cpp.yaml
+++ b/test/specs/issues/134.cpp.yaml
@@ -124,6 +124,7 @@
     - punctuation.section.parameters.begin.bracket.round.function.pointer
 - source: Type
   scopes:
+    - meta.parameter
     - entity.name.type.parameter
 - source: )
   scopes:
@@ -179,6 +180,7 @@
     - punctuation.section.parameters.begin.bracket.round.function.pointer
 - source: Type
   scopes:
+    - meta.parameter
     - entity.name.type.parameter
 - source: )
   scopes:
@@ -308,6 +310,7 @@
     - punctuation.section.parameters.begin.bracket.round.function.pointer
 - source: Type
   scopes:
+    - meta.parameter
     - entity.name.type.parameter
 - source: )
   scopes:
@@ -367,6 +370,7 @@
     - punctuation.section.parameters.begin.bracket.round.function.pointer
 - source: Type
   scopes:
+    - meta.parameter
     - entity.name.type.parameter
 - source: )
   scopes:

--- a/test/specs/vscode/misc.mm.yaml
+++ b/test/specs/vscode/misc.mm.yaml
@@ -18,6 +18,8 @@
   scopes:
     - entity.scope.name
 - source: '::'
+  scopes:
+    - punctuation.separator.namespace.access
   scopesEnd:
     - punctuation.separator.namespace.access
 - source: optional
@@ -560,6 +562,8 @@
   scopes:
     - entity.scope.name
 - source: '::'
+  scopes:
+    - punctuation.separator.namespace.access
   scopesEnd:
     - punctuation.separator.namespace.access
 - source: vector
@@ -752,6 +756,8 @@
   scopes:
     - entity.scope.name
 - source: '::'
+  scopes:
+    - punctuation.separator.namespace.access
   scopesEnd:
     - punctuation.separator.namespace.access
 - source: 'cout '
@@ -907,6 +913,8 @@
   scopes:
     - entity.scope.name
 - source: '::'
+  scopes:
+    - punctuation.separator.namespace.access
   scopesEnd:
     - punctuation.separator.namespace.access
 - source: 'cout '
@@ -1062,6 +1070,8 @@
   scopes:
     - entity.scope.name
 - source: '::'
+  scopes:
+    - punctuation.separator.namespace.access
   scopesEnd:
     - punctuation.separator.namespace.access
 - source: 'cout '

--- a/test/specs/vscode/misc005.cpp.yaml
+++ b/test/specs/vscode/misc005.cpp.yaml
@@ -29824,6 +29824,8 @@
   scopes:
     - punctuation.section.arguments.begin.bracket.round.decltype
 - source: ARG
+  scopes:
+    - meta.arguments.decltype
 - source: )
   scopes:
     - punctuation.section.arguments.end.bracket.round.decltype
@@ -29901,6 +29903,8 @@
   scopes:
     - punctuation.section.arguments.begin.bracket.round.decltype
 - source: ARG
+  scopes:
+    - meta.arguments.decltype
 - source: )
   scopes:
     - punctuation.section.arguments.end.bracket.round.decltype


### PR DESCRIPTION
difference is not acceptable to split scopes as scopes may be
duplicated.

The following tests were regenerated:
 - issues/134.cpp
 - vscode/misc.mm
 - vscode/misc005.cpp

Fixes, part of #272 misc004.m is still broken.