### PR TITLE
make paths.js not rely on node >= 11.0

### DIFF
--- a/test/source/paths.js
+++ b/test/source/paths.js
@@ -1,6 +1,7 @@
 const path = require("path");
 const glob = require("glob");
 const fs   = require("fs");
+const _ = require("lodash")
 
 const testDir            = path.dirname(__dirname)
 const fixtures           = path.join(testDir, "fixtures")
@@ -19,6 +20,6 @@ module.exports = {
     languages:      path.join(root, "source", "languages"),
     eachLanguage:   glob.sync(path.join(root, "source/languages/*")),
     eachJsonSyntax: glob.sync(path.join(syntaxes, "*.json")),
-    eachFixture:    glob.sync(path.join(fixtures,`**/*.{${languageFileTypes.flat().join(",")}}`)),
+    eachFixture:    glob.sync(path.join(fixtures,`**/*.{${_.flattenDeep(languageFileTypes).join(",")}}`)),
     jsonSyntax:     (extensionName) => path.join(syntaxes, `${extensionName}.tmLanguage.json`)
 }


### PR DESCRIPTION
Array.proptotype.flat was only added to nodejs 11.0. LTS versions 8.x and
10.x are still actively maintained and should not be excluded when there
is an equivalent function.