### PR TITLE
Fix issue with spec generation

### DIFF
--- a/syntaxes/dockerfile.tmLanguage.json
+++ b/syntaxes/dockerfile.tmLanguage.json
@@ -1747,7 +1747,7 @@
         },
         "assignment": {
           "name": "meta.expression.assignment.shell.dockerfile",
-          "begin": "((?:^|\\b)[a-zA-Z_][a-zA-Z0-9_]*+(?:\\b|$))(\\=)",
+          "begin": "\\s*+((?:^|\\b)[a-zA-Z_][a-zA-Z0-9_]*+(?:\\b|$))(\\=)",
           "beginCaptures": {
             "1": {
               "name": "variable.other.assignment.shell.dockerfile"

--- a/syntaxes/dockerfile.tmLanguage.yaml
+++ b/syntaxes/dockerfile.tmLanguage.yaml
@@ -959,7 +959,7 @@ repository:
             name: punctuation.separator.statement.background.shell.dockerfile
       assignment:
         name: meta.expression.assignment.shell.dockerfile
-        begin: "((?:^|\\b)[a-zA-Z_][a-zA-Z0-9_]*+(?:\\b|$))(\\=)"
+        begin: "\\s*+((?:^|\\b)[a-zA-Z_][a-zA-Z0-9_]*+(?:\\b|$))(\\=)"
         beginCaptures:
           '1':
             name: variable.other.assignment.shell.dockerfile

--- a/test/source/generate_spec.js
+++ b/test/source/generate_spec.js
@@ -1,9 +1,9 @@
 const getTokens = require("./get_tokens");
 const registry = require("./registry").default;
 const _ = require("lodash");
-const path = require("path")
-const paths = require("./paths")
-const {removeScopeName} = require("./utils")
+const path = require("path");
+const paths = require("./paths");
+const { removeScopeName } = require("./utils");
 
 /**
  * @param {string} path
@@ -67,8 +67,10 @@ module.exports = async function generateSpec(path, fixture) {
             // add to scopesEnd all scopes that scopeStack has but next does not
             let nextIndex = 0;
             let scopesEnd = [];
+            let scopesMatch = true;
             for (let scope of scopeStack) {
-                if (scope !== next.scopes[nextIndex]) {
+                if (scope !== next.scopes[nextIndex] || !scopesMatch) {
+                    scopesMatch = false;
                     scopesEnd.push(scope);
                 }
                 nextIndex += 1;
@@ -78,6 +80,15 @@ module.exports = async function generateSpec(path, fixture) {
                 for (let scope of scopesEnd.slice().reverse()) {
                     if (scope === scopeStack[scopeStack.length - 1]) {
                         scopeStack.pop();
+                    } else {
+                        console.error(
+                            "Expected top of scope stack to be %s, but found %s",
+                            scope,
+                            scopeStack[scopeStack.length - 1]
+                        );
+                        console.error(scopesEnd);
+                        console.error(object.source, object.scopes);
+                        console.error(next.source, next.scopes);
                     }
                 }
                 let nonLocalScopes = [...scopeStack, ...scopesEnd];

--- a/test/specs/vscode/misc004.m.yaml
+++ b/test/specs/vscode/misc004.m.yaml
@@ -79,16 +79,17 @@
 - source: end
   scopesEnd:
     - meta.interface-or-protocol
-- source: '@'
-  scopesEnd:
-    - meta.interface-or-protocol
-- source: implementation
-  scopesEnd:
-    - meta.interface-or-protocol
     - storage.type
-- source: ViewController
+- source: '@'
   scopesBegin:
     - meta.implementation
+    - storage.type
+  scopes:
+    - punctuation.definition.storage.type
+- source: implementation
+  scopesEnd:
+    - storage.type
+- source: ViewController
   scopes:
     - entity.name.type
 - source: '- '


### PR DESCRIPTION
As part of deciding what scopes have ended, the spec generator incorrectly concluded that scopes the matched after a scope mismatch did not end. This PR fixes that behavior.

fixes: #272