### PR TITLE
Fix specifiers for operator overloads

### DIFF
--- a/source/languages/cpp/generate.rb
+++ b/source/languages/cpp/generate.rb
@@ -1174,6 +1174,7 @@ cpp_grammar = Grammar.new(
                     :evaluation_context,
                 ]
             ),
+            :qualifiers_and_specifiers_post_parameters,
             # initial context is here for things like noexcept()
             # TODO: fix this pattern an make it more strict
             :$initial_context

--- a/syntaxes/cpp.tmLanguage.json
+++ b/syntaxes/cpp.tmLanguage.json
@@ -5713,6 +5713,9 @@
               ]
             },
             {
+              "include": "#qualifiers_and_specifiers_post_parameters"
+            },
+            {
               "include": "$self"
             }
           ]
@@ -17362,6 +17365,9 @@
                   "include": "#evaluation_context"
                 }
               ]
+            },
+            {
+              "include": "#qualifiers_and_specifiers_post_parameters"
             },
             {
               "include": "$self"

--- a/syntaxes/cpp.tmLanguage.yaml
+++ b/syntaxes/cpp.tmLanguage.yaml
@@ -2925,6 +2925,7 @@ repository:
         patterns:
         - include: "#function_parameter_context"
         - include: "#evaluation_context"
+      - include: "#qualifiers_and_specifiers_post_parameters"
       - include: "$self"
     - name: meta.body.function.definition.special.operator-overload.cpp
       begin: "(?<=\\{|<%|\\?\\?<)"
@@ -9037,6 +9038,7 @@ repository:
         patterns:
         - include: "#function_parameter_context"
         - include: "#evaluation_context"
+      - include: "#qualifiers_and_specifiers_post_parameters"
       - include: "$self"
     - name: meta.body.function.definition.special.operator-overload.cpp
       begin: "(?<=\\{|<%|\\?\\?<)"

--- a/test/specs/features/operator_overload.cpp.yaml
+++ b/test/specs/features/operator_overload.cpp.yaml
@@ -434,7 +434,7 @@
     - punctuation.section.parameters.end.bracket.round.special.operator-overload
 - source: const
   scopes:
-    - storage.modifier.specifier.const
+    - storage.modifier.specifier.functional.post-parameters.const
 - source: noexcept
   scopes:
     - storage.modifier.specifier.functional.post-parameters.noexcept
@@ -486,7 +486,7 @@
     - punctuation.section.parameters.end.bracket.round.special.operator-overload
 - source: const
   scopes:
-    - storage.modifier.specifier.const
+    - storage.modifier.specifier.functional.post-parameters.const
 - source: noexcept
   scopes:
     - storage.modifier.specifier.functional.post-parameters.noexcept
@@ -545,7 +545,7 @@
     - punctuation.section.parameters.end.bracket.round.special.operator-overload
 - source: const
   scopes:
-    - storage.modifier.specifier.const
+    - storage.modifier.specifier.functional.post-parameters.const
 - source: '{'
   scopes:
     - >-
@@ -574,7 +574,7 @@
     - punctuation.section.parameters.end.bracket.round.special.operator-overload
 - source: const
   scopes:
-    - storage.modifier.specifier.const
+    - storage.modifier.specifier.functional.post-parameters.const
 - source: '{'
   scopes:
     - >-

--- a/test/specs/issues/082.cpp.yaml
+++ b/test/specs/issues/082.cpp.yaml
@@ -188,7 +188,7 @@
     - punctuation.section.parameters.end.bracket.round.special.operator-overload
 - source: const
   scopes:
-    - storage.modifier.specifier.const
+    - storage.modifier.specifier.functional.post-parameters.const
 - source: '{'
   scopes:
     - >-
@@ -547,7 +547,7 @@
     - punctuation.section.parameters.end.bracket.round.special.operator-overload
 - source: const
   scopes:
-    - storage.modifier.specifier.const
+    - storage.modifier.specifier.functional.post-parameters.const
 - source: '{'
   scopes:
     - >-

--- a/test/specs/vscode/example.cpp.yaml
+++ b/test/specs/vscode/example.cpp.yaml
@@ -3715,7 +3715,7 @@
     - punctuation.section.parameters.end.bracket.round.special.operator-overload
 - source: const
   scopes:
-    - storage.modifier.specifier.const
+    - storage.modifier.specifier.functional.post-parameters.const
 - source: '{'
   scopes:
     - >-
@@ -3750,7 +3750,7 @@
     - punctuation.section.parameters.end.bracket.round.special.operator-overload
 - source: const
   scopes:
-    - storage.modifier.specifier.const
+    - storage.modifier.specifier.functional.post-parameters.const
 - source: '{'
   scopes:
     - >-
@@ -6124,7 +6124,7 @@
     - punctuation.section.parameters.end.bracket.round.special.operator-overload
 - source: const
   scopes:
-    - storage.modifier.specifier.const
+    - storage.modifier.specifier.functional.post-parameters.const
 - source: '{'
   scopes:
     - >-

--- a/test/specs/vscode/misc005.cpp.yaml
+++ b/test/specs/vscode/misc005.cpp.yaml
@@ -47762,7 +47762,7 @@
     - punctuation.section.parameters.end.bracket.round.special.operator-overload
 - source: const
   scopes:
-    - storage.modifier.specifier.const
+    - storage.modifier.specifier.functional.post-parameters.const
 - source: '{'
   scopes:
     - >-
@@ -47801,7 +47801,7 @@
     - punctuation.section.parameters.end.bracket.round.special.operator-overload
 - source: const
   scopes:
-    - storage.modifier.specifier.const
+    - storage.modifier.specifier.functional.post-parameters.const
 - source: '{'
   scopes:
     - >-


### PR DESCRIPTION
What caused the issue described in https://github.com/jeff-hykin/cpp-textmate-grammar/issues/301#issuecomment-510792204 was that the operator_overload pattern was not updated.