### PR TITLE
make the OnigScanner wrapper match the behavior of the actual OnigScanner

### DIFF
--- a/test/source/report/onig_scanner.js
+++ b/test/source/report/onig_scanner.js
@@ -45,6 +45,9 @@ module.exports = class OnigScanner {
             } catch (e) {
                 console.log(this.patterns[index]);
             }
+            if (match[0].start == startPosition) {
+                break;
+            }
         }
         // chose the best match
         // best match means the match with the earliest starting position for the 0th sub-expression


### PR DESCRIPTION
OnigScanner stops checking early if the earliest possible match has been found. This PR makes the OnigScanner wrapper match that behavior.