### PR TITLE
Add invalid tag for unexpected end of block comment

### DIFF
--- a/language_tags/cpp.txt
+++ b/language_tags/cpp.txt
@@ -330,6 +330,7 @@ invalid.illegal.constant.numeric.cpp
 invalid.illegal.delimiter-too-long.cpp
 invalid.illegal.macro-name.cpp
 invalid.illegal.reference-type.cpp
+invalid.illegal.unexpected.punctuation.definition.comment.end.cpp
 invalid.illegal.unknown-escape.cpp
 keyword.control.$5.cpp
 keyword.control.case.cpp

--- a/source/languages/cpp/generate.rb
+++ b/source/languages/cpp/generate.rb
@@ -385,10 +385,15 @@ cpp_grammar = Grammar.new(
             tag_as: "meta.toc-list.banner.block",
         )
     )
+    cpp_grammar[:invalid_comment_end] = newPattern(
+        match: /\*\//,
+        tag_as: "invalid.illegal.unexpected.punctuation.definition.comment.end"
+    )
     cpp_grammar[:comments] = [
         :emacs_file_banner,
         :block_comment,
         :line_comment,
+        :invalid_comment_end,
     ]
 #
 # Numbers

--- a/syntaxes/cpp.tmLanguage.json
+++ b/syntaxes/cpp.tmLanguage.json
@@ -522,6 +522,10 @@
         }
       }
     },
+    "invalid_comment_end": {
+      "match": "\\*\\/",
+      "name": "invalid.illegal.unexpected.punctuation.definition.comment.end.cpp"
+    },
     "comments": {
       "patterns": [
         {
@@ -532,6 +536,9 @@
         },
         {
           "include": "#line_comment"
+        },
+        {
+          "include": "#invalid_comment_end"
         }
       ]
     },

--- a/syntaxes/cpp.tmLanguage.yaml
+++ b/syntaxes/cpp.tmLanguage.yaml
@@ -219,11 +219,15 @@ repository:
         name: punctuation.definition.comment.cpp
       '8':
         name: meta.banner.character.cpp
+  invalid_comment_end:
+    match: "\\*\\/"
+    name: invalid.illegal.unexpected.punctuation.definition.comment.end.cpp
   comments:
     patterns:
     - include: "#emacs_file_banner"
     - include: "#block_comment"
     - include: "#line_comment"
+    - include: "#invalid_comment_end"
   number_literal:
     begin: "(?<!\\w)(?=\\d|\\.\\d)"
     end: "(?!(?:(?:[0-9a-zA-Z_\\.]|')|(?<=[eEpP])[+-]))"


### PR DESCRIPTION
Example:
![Screenshot from 2019-07-19 13-36-45](https://user-images.githubusercontent.com/714007/61564209-c90e0b80-aa2a-11e9-9324-72ba68433a21.png)
