### PR TITLE
Fix preprocessor macro arguments

### DIFF
--- a/language_tags/c.txt
+++ b/language_tags/c.txt
@@ -20,6 +20,7 @@ constant.numeric.octal.c
 constant.numeric.preprocessor.c
 constant.other.placeholder.c
 constant.other.variable.mac-classic.c
+ellipses.c
 entity.name.function.c
 entity.name.function.member.c
 entity.name.function.preprocessor.c
@@ -391,6 +392,7 @@ punctuation.separator.parameters.c
 punctuation.separator.pointer-access.c
 punctuation.terminator.statement.c
 punctuation.vararg-ellipses.c
+punctuation.vararg-ellipses.variable.parameter.preprocessor.c
 punctuation.whitespace.comment.leading.c
 storage.modifier.array.bracket.square.c
 storage.modifier.c

--- a/language_tags/cpp.txt
+++ b/language_tags/cpp.txt
@@ -19,7 +19,6 @@ constant.numeric.hexadecimal.cpp
 constant.numeric.octal.cpp
 constant.numeric.preprocessor.cpp
 constant.other.placeholder.cpp
-ellipses.cpp
 entity.name.function.call.cpp
 entity.name.function.call.initializer.cpp
 entity.name.function.constructor.cpp

--- a/language_tags/cpp.txt
+++ b/language_tags/cpp.txt
@@ -616,6 +616,7 @@ punctuation.separator.scope-resolution.template.definition.cpp
 punctuation.terminator.statement.cpp
 punctuation.vararg-ellipses.cpp
 punctuation.vararg-ellipses.template.definition.cpp
+punctuation.vararg-ellipses.variable.parameter.preprocessor.cpp
 storage.modifier.$0.cpp
 storage.modifier.$11.cpp
 storage.modifier.array.bracket.square.cpp

--- a/source/languages/cpp/generate.rb
+++ b/source/languages/cpp/generate.rb
@@ -839,7 +839,7 @@ cpp_grammar = Grammar.new(
                     tag_as: "storage.type.template",
                 ).maybe(@spaces).then(
                     match: /\.\.\./,
-                    tag_as: "ellipses punctuation.vararg-ellipses.template.definition",
+                    tag_as: "punctuation.vararg-ellipses.template.definition",
                 ).maybe(@spaces).then(
                     match: variable_name_without_bounds,
                     tag_as: "entity.name.type.template"
@@ -2387,7 +2387,7 @@ cpp_grammar = Grammar.new(
                 ),
                 newPattern(
                     match: /\.\.\./,
-                    tag_as: "ellipses punctuation.vararg-ellipses.variable.parameter.preprocessor"
+                    tag_as: "punctuation.vararg-ellipses.variable.parameter.preprocessor"
                 )
             ]
         ).then(

--- a/syntaxes/c.tmLanguage.json
+++ b/syntaxes/c.tmLanguage.json
@@ -70,32 +70,71 @@
       "include": "#strings"
     },
     {
-      "begin": "(?x)\n^\\s* ((\\#)\\s*define) \\s+\t# define\n((?<id>[a-zA-Z_$][\\w$]*))\t  # macro name\n(?:\n  (\\()\n\t(\n\t  \\s* \\g<id> \\s*\t\t # first argument\n\t  ((,) \\s* \\g<id> \\s*)*  # additional arguments\n\t  (?:\\.\\.\\.)?\t\t\t# varargs ellipsis?\n\t)\n  (\\))\n)?",
+      "name": "meta.preprocessor.macro.c",
+      "begin": "((?:(?:(?>\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+?|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))((#)\\s*define\\b)\\s+((?<!\\w)[a-zA-Z_]\\w*(?!\\w))(?:(\\()([^()\\\\]+)(\\)))?",
       "beginCaptures": {
         "1": {
-          "name": "keyword.control.directive.define.c"
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
         },
         "2": {
-          "name": "punctuation.definition.directive.c"
+          "name": "comment.block.c punctuation.definition.comment.begin.c"
         },
         "3": {
-          "name": "entity.name.function.preprocessor.c"
+          "name": "comment.block.c"
+        },
+        "4": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.c punctuation.definition.comment.end.c"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.c"
+            }
+          ]
         },
         "5": {
-          "name": "punctuation.definition.parameters.begin.c"
+          "name": "keyword.control.directive.define.c"
         },
         "6": {
-          "name": "variable.parameter.preprocessor.c"
+          "name": "punctuation.definition.directive.c"
+        },
+        "7": {
+          "name": "entity.name.function.preprocessor.c"
         },
         "8": {
-          "name": "punctuation.separator.parameters.c"
+          "name": "punctuation.definition.parameters.begin.c"
         },
         "9": {
+          "patterns": [
+            {
+              "match": "(?<=[(,])\\s*((?<!\\w)[a-zA-Z_]\\w*(?!\\w))\\s*",
+              "captures": {
+                "1": {
+                  "name": "variable.parameter.preprocessor.c"
+                }
+              }
+            },
+            {
+              "match": ",",
+              "name": "punctuation.separator.parameters.c"
+            },
+            {
+              "match": "\\.\\.\\.",
+              "name": "ellipses.c punctuation.vararg-ellipses.variable.parameter.preprocessor.c"
+            }
+          ]
+        },
+        "10": {
           "name": "punctuation.definition.parameters.end.c"
         }
       },
-      "end": "(?=(?://|/\\*))|(?<!\\\\)(?=\\n)",
-      "name": "meta.preprocessor.macro.c",
+      "end": "(?<!\\\\)(?=\\n)",
       "patterns": [
         {
           "include": "#preprocessor-rule-define-line-contents"
@@ -375,6 +414,29 @@
     }
   ],
   "repository": {
+    "inline_comment": {
+      "match": "(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/))",
+      "captures": {
+        "1": {
+          "name": "comment.block.c punctuation.definition.comment.begin.c"
+        },
+        "2": {
+          "name": "comment.block.c"
+        },
+        "3": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.c punctuation.definition.comment.end.c"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.c"
+            }
+          ]
+        }
+      }
+    },
     "default_statement": {
       "name": "meta.conditional.case.c",
       "begin": "((?:(?:(?>\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+?|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))((?<!\\w)default(?!\\w))",

--- a/syntaxes/c.tmLanguage.yaml
+++ b/syntaxes/c.tmLanguage.yaml
@@ -33,27 +33,43 @@ patterns:
 - include: "#operators"
 - include: "#numbers"
 - include: "#strings"
-- begin: "(?x)\n^\\s* ((\\#)\\s*define) \\s+\t# define\n((?<id>[a-zA-Z_$][\\w$]*))\t
-    \ # macro name\n(?:\n  (\\()\n\t(\n\t  \\s* \\g<id> \\s*\t\t # first argument\n\t
-    \ ((,) \\s* \\g<id> \\s*)*  # additional arguments\n\t  (?:\\.\\.\\.)?\t\t\t#
-    varargs ellipsis?\n\t)\n  (\\))\n)?"
+- name: meta.preprocessor.macro.c
+  begin: "((?:(?:(?>\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+?|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))((#)\\s*define\\b)\\s+((?<!\\w)[a-zA-Z_]\\w*(?!\\w))(?:(\\()([^()\\\\]+)(\\)))?"
   beginCaptures:
     '1':
-      name: keyword.control.directive.define.c
+      patterns:
+      - include: "#inline_comment"
     '2':
-      name: punctuation.definition.directive.c
+      name: comment.block.c punctuation.definition.comment.begin.c
     '3':
-      name: entity.name.function.preprocessor.c
+      name: comment.block.c
+    '4':
+      patterns:
+      - match: "\\*\\/"
+        name: comment.block.c punctuation.definition.comment.end.c
+      - match: "\\*"
+        name: comment.block.c
     '5':
-      name: punctuation.definition.parameters.begin.c
+      name: keyword.control.directive.define.c
     '6':
-      name: variable.parameter.preprocessor.c
+      name: punctuation.definition.directive.c
+    '7':
+      name: entity.name.function.preprocessor.c
     '8':
-      name: punctuation.separator.parameters.c
+      name: punctuation.definition.parameters.begin.c
     '9':
+      patterns:
+      - match: "(?<=[(,])\\s*((?<!\\w)[a-zA-Z_]\\w*(?!\\w))\\s*"
+        captures:
+          '1':
+            name: variable.parameter.preprocessor.c
+      - match: ","
+        name: punctuation.separator.parameters.c
+      - match: "\\.\\.\\."
+        name: ellipses.c punctuation.vararg-ellipses.variable.parameter.preprocessor.c
+    '10':
       name: punctuation.definition.parameters.end.c
-  end: "(?=(?://|/\\*))|(?<!\\\\)(?=\\n)"
-  name: meta.preprocessor.macro.c
+  end: "(?<!\\\\)(?=\\n)"
   patterns:
   - include: "#preprocessor-rule-define-line-contents"
 - begin: "^\\s*((#)\\s*(error|warning))\\b\\s*"
@@ -216,6 +232,19 @@ patterns:
 - match: ","
   name: punctuation.separator.delimiter.c
 repository:
+  inline_comment:
+    match: "(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/))"
+    captures:
+      '1':
+        name: comment.block.c punctuation.definition.comment.begin.c
+      '2':
+        name: comment.block.c
+      '3':
+        patterns:
+        - match: "\\*\\/"
+          name: comment.block.c punctuation.definition.comment.end.c
+        - match: "\\*"
+          name: comment.block.c
   default_statement:
     name: meta.conditional.case.c
     begin: "((?:(?:(?>\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+?|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))((?<!\\w)default(?!\\w))"

--- a/syntaxes/cpp.tmLanguage.json
+++ b/syntaxes/cpp.tmLanguage.json
@@ -2095,7 +2095,7 @@
           "name": "storage.type.template.cpp"
         },
         "9": {
-          "name": "ellipses.cpp punctuation.vararg-ellipses.template.definition.cpp"
+          "name": "punctuation.vararg-ellipses.template.definition.cpp"
         },
         "10": {
           "name": "entity.name.type.template.cpp"
@@ -14129,7 +14129,7 @@
             },
             {
               "match": "\\.\\.\\.",
-              "name": "ellipses.cpp punctuation.vararg-ellipses.variable.parameter.preprocessor.cpp"
+              "name": "punctuation.vararg-ellipses.variable.parameter.preprocessor.cpp"
             }
           ]
         },

--- a/syntaxes/cpp.tmLanguage.json
+++ b/syntaxes/cpp.tmLanguage.json
@@ -14074,31 +14074,70 @@
     },
     "meta_preprocessor_macro": {
       "name": "meta.preprocessor.macro.cpp",
-      "begin": "(?x)\n^\\s* ((\\#)\\s*define) \\s+\t# define\n((?<id>(?-mix:[a-zA-Z_$][\\w$]*)))\t  # macro name\n(?:\n  (\\()\n\t(\n\t  \\s* \\g<id> \\s*\t\t # first argument\n\t  ((,) \\s* \\g<id> \\s*)*  # additional arguments\n\t  (?:\\.\\.\\.)?\t\t\t# varargs ellipsis?\n\t)\n  (\\))\n)?",
+      "begin": "((?:(?:(?>\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+?|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))((#)\\s*define\\b)\\s+((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)(?:(\\()([^()\\\\]+)(\\)))?",
       "beginCaptures": {
         "1": {
-          "name": "keyword.control.directive.define.cpp"
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
         },
         "2": {
-          "name": "punctuation.definition.directive.cpp"
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
         },
         "3": {
-          "name": "entity.name.function.preprocessor.cpp"
+          "name": "comment.block.cpp"
+        },
+        "4": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
         },
         "5": {
-          "name": "punctuation.definition.parameters.begin.cpp"
+          "name": "keyword.control.directive.define.cpp"
         },
         "6": {
-          "name": "variable.parameter.preprocessor.cpp"
+          "name": "punctuation.definition.directive.cpp"
+        },
+        "7": {
+          "name": "entity.name.function.preprocessor.cpp"
         },
         "8": {
-          "name": "punctuation.separator.parameters.cpp"
+          "name": "punctuation.definition.parameters.begin.cpp"
         },
         "9": {
+          "patterns": [
+            {
+              "match": "(?<=[(,])\\s*((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)\\s*",
+              "captures": {
+                "1": {
+                  "name": "variable.parameter.preprocessor.cpp"
+                }
+              }
+            },
+            {
+              "match": ",",
+              "name": "punctuation.separator.parameters.cpp"
+            },
+            {
+              "match": "\\.\\.\\.",
+              "name": "ellipses.cpp punctuation.vararg-ellipses.variable.parameter.preprocessor.cpp"
+            }
+          ]
+        },
+        "10": {
           "name": "punctuation.definition.parameters.end.cpp"
         }
       },
-      "end": "(?=(?://|/\\*))|(?<!\\\\)(?=\\n)",
+      "end": "(?<!\\\\)(?=\\n)",
       "patterns": [
         {
           "include": "#macro_context"

--- a/syntaxes/cpp.tmLanguage.yaml
+++ b/syntaxes/cpp.tmLanguage.yaml
@@ -1089,7 +1089,7 @@ repository:
       '8':
         name: storage.type.template.cpp
       '9':
-        name: ellipses.cpp punctuation.vararg-ellipses.template.definition.cpp
+        name: punctuation.vararg-ellipses.template.definition.cpp
       '10':
         name: entity.name.type.template.cpp
       '11':
@@ -7311,7 +7311,7 @@ repository:
         - match: ","
           name: punctuation.separator.parameters.cpp
         - match: "\\.\\.\\."
-          name: ellipses.cpp punctuation.vararg-ellipses.variable.parameter.preprocessor.cpp
+          name: punctuation.vararg-ellipses.variable.parameter.preprocessor.cpp
       '10':
         name: punctuation.definition.parameters.end.cpp
     end: "(?<!\\\\)(?=\\n)"

--- a/syntaxes/cpp.tmLanguage.yaml
+++ b/syntaxes/cpp.tmLanguage.yaml
@@ -7279,26 +7279,42 @@ repository:
     name: storage.modifier.$0.cpp
   meta_preprocessor_macro:
     name: meta.preprocessor.macro.cpp
-    begin: "(?x)\n^\\s* ((\\#)\\s*define) \\s+\t# define\n((?<id>(?-mix:[a-zA-Z_$][\\w$]*)))\t
-      \ # macro name\n(?:\n  (\\()\n\t(\n\t  \\s* \\g<id> \\s*\t\t # first argument\n\t
-      \ ((,) \\s* \\g<id> \\s*)*  # additional arguments\n\t  (?:\\.\\.\\.)?\t\t\t#
-      varargs ellipsis?\n\t)\n  (\\))\n)?"
+    begin: "((?:(?:(?>\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+?|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))((#)\\s*define\\b)\\s+((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)(?:(\\()([^()\\\\]+)(\\)))?"
     beginCaptures:
       '1':
-        name: keyword.control.directive.define.cpp
+        patterns:
+        - include: "#inline_comment"
       '2':
-        name: punctuation.definition.directive.cpp
+        name: comment.block.cpp punctuation.definition.comment.begin.cpp
       '3':
-        name: entity.name.function.preprocessor.cpp
+        name: comment.block.cpp
+      '4':
+        patterns:
+        - match: "\\*\\/"
+          name: comment.block.cpp punctuation.definition.comment.end.cpp
+        - match: "\\*"
+          name: comment.block.cpp
       '5':
-        name: punctuation.definition.parameters.begin.cpp
+        name: keyword.control.directive.define.cpp
       '6':
-        name: variable.parameter.preprocessor.cpp
+        name: punctuation.definition.directive.cpp
+      '7':
+        name: entity.name.function.preprocessor.cpp
       '8':
-        name: punctuation.separator.parameters.cpp
+        name: punctuation.definition.parameters.begin.cpp
       '9':
+        patterns:
+        - match: "(?<=[(,])\\s*((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)\\s*"
+          captures:
+            '1':
+              name: variable.parameter.preprocessor.cpp
+        - match: ","
+          name: punctuation.separator.parameters.cpp
+        - match: "\\.\\.\\."
+          name: ellipses.cpp punctuation.vararg-ellipses.variable.parameter.preprocessor.cpp
+      '10':
         name: punctuation.definition.parameters.end.cpp
-    end: "(?=(?://|/\\*))|(?<!\\\\)(?=\\n)"
+    end: "(?<!\\\\)(?=\\n)"
     patterns:
     - include: "#macro_context"
   meta_preprocessor_diagnostic:

--- a/test/fixtures/issues/324.cpp
+++ b/test/fixtures/issues/324.cpp
@@ -1,11 +1,11 @@
-#define HARVEST_REQUEST_PARAM_APPEND(string, key, value, edited, ampersand)     \
-	do {                                                                      \
+#define HARVEST_REQUEST_PARAM_APPEND(string, key, value, edited, ampersand) \
+	do {                                                                    \
 		(if(edited) {                                                       \
-			if(ampersand) {                                               \
-				g_string_append_printf(string, "&%s=%s", #key, #value); \
-			} else {                                                      \
-				ampersand = TRUE;                                       \
-				g_string_append_printf(string, "%s=%s", #key, #value);  \
-			}                                                             \
+			if(ampersand) {                                                 \
+				g_string_append_printf(string, "&%s=%s", #key, #value);     \
+			} else {                                                        \
+				ampersand = TRUE;                                           \
+				g_string_append_printf(string, "%s=%s", #key, #value);      \
+			}                                                               \
 		})                                                                  \
 	} while(0)

--- a/test/fixtures/issues/324.cpp
+++ b/test/fixtures/issues/324.cpp
@@ -1,0 +1,11 @@
+#define HARVEST_REQUEST_PARAM_APPEND(string, key, value, edited, ampersand)     \
+	do {                                                                      \
+		(if(edited) {                                                       \
+			if(ampersand) {                                               \
+				g_string_append_printf(string, "&%s=%s", #key, #value); \
+			} else {                                                      \
+				ampersand = TRUE;                                       \
+				g_string_append_printf(string, "%s=%s", #key, #value);  \
+			}                                                             \
+		})                                                                  \
+	} while(0)

--- a/test/specs/features/parameters.cpp.yaml
+++ b/test/specs/features/parameters.cpp.yaml
@@ -1920,7 +1920,6 @@
     - storage.type.template
 - source: ...
   scopes:
-    - ellipses
     - punctuation.vararg-ellipses.template.definition
 - source: Args
   scopes:

--- a/test/specs/features/preprocessor.cpp.yaml
+++ b/test/specs/features/preprocessor.cpp.yaml
@@ -248,7 +248,6 @@
     - punctuation.definition.parameters.begin
 - source: ...
   scopes:
-    - ellipses
     - punctuation.vararg-ellipses.variable.parameter.preprocessor
 - source: )
   scopes:

--- a/test/specs/features/preprocessor.cpp.yaml
+++ b/test/specs/features/preprocessor.cpp.yaml
@@ -76,13 +76,13 @@
   scopes:
     - punctuation.definition.parameters.begin
 - source: arg1
-  scopesBegin:
+  scopes:
     - variable.parameter.preprocessor
 - source: ','
   scopes:
     - punctuation.separator.parameters
-- source: ' arg2'
-  scopesEnd:
+- source: arg2
+  scopes:
     - variable.parameter.preprocessor
 - source: )
   scopes:
@@ -103,13 +103,13 @@
   scopes:
     - punctuation.definition.parameters.begin
 - source: arg1
-  scopesBegin:
+  scopes:
     - variable.parameter.preprocessor
 - source: ','
   scopes:
     - punctuation.separator.parameters
-- source: ' arg2'
-  scopesEnd:
+- source: arg2
+  scopes:
     - variable.parameter.preprocessor
 - source: )
   scopes:
@@ -244,18 +244,15 @@
   scopes:
     - entity.name.function.preprocessor
 - source: (
-  scopesBegin:
-    - meta.parens
   scopes:
-    - punctuation.section.parens.begin.bracket.round
+    - punctuation.definition.parameters.begin
 - source: ...
   scopes:
-    - punctuation.vararg-ellipses
+    - ellipses
+    - punctuation.vararg-ellipses.variable.parameter.preprocessor
 - source: )
   scopes:
-    - punctuation.section.parens.end.bracket.round
-  scopesEnd:
-    - meta.parens
+    - punctuation.definition.parameters.end
 - source: \
   scopes:
     - constant.character.escape.line-continuation

--- a/test/specs/issues/027.c.yaml
+++ b/test/specs/issues/027.c.yaml
@@ -8,7 +8,19 @@
     - punctuation.definition.comment.end
   scopesEnd:
     - comment.block
-- source: ' #define a cout '
+- source: '#'
+  scopesBegin:
+    - meta.preprocessor.macro
+    - keyword.control.directive.define
+  scopes:
+    - punctuation.definition.directive
+- source: define
+  scopesEnd:
+    - keyword.control.directive.define
+- source: a
+  scopes:
+    - entity.name.function.preprocessor
+- source: ' cout '
 - source: '<<'
   scopes:
     - keyword.operator.bitwise.shift

--- a/test/specs/issues/027.cpp.yaml
+++ b/test/specs/issues/027.cpp.yaml
@@ -1,5 +1,6 @@
 - source: /*
   scopesBegin:
+    - meta.preprocessor.macro
     - comment.block
   scopes:
     - punctuation.definition.comment.begin
@@ -8,7 +9,18 @@
     - punctuation.definition.comment.end
   scopesEnd:
     - comment.block
-- source: ' #define a cout '
+- source: '#'
+  scopesBegin:
+    - keyword.control.directive.define
+  scopes:
+    - punctuation.definition.directive
+- source: define
+  scopesEnd:
+    - keyword.control.directive.define
+- source: a
+  scopes:
+    - entity.name.function.preprocessor
+- source: ' cout '
 - source: '<<'
   scopes:
     - keyword.operator.bitwise.shift

--- a/test/specs/issues/030.cpp.yaml
+++ b/test/specs/issues/030.cpp.yaml
@@ -46,18 +46,15 @@
   scopes:
     - entity.name.function.preprocessor
 - source: (
-  scopesBegin:
-    - meta.parens
   scopes:
-    - punctuation.section.parens.begin.bracket.round
+    - punctuation.definition.parameters.begin
 - source: ...
   scopes:
-    - punctuation.vararg-ellipses
+    - ellipses
+    - punctuation.vararg-ellipses.variable.parameter.preprocessor
 - source: )
   scopes:
-    - punctuation.section.parens.end.bracket.round
-  scopesEnd:
-    - meta.parens
+    - punctuation.definition.parameters.end
 - source: \
   scopes:
     - constant.character.escape.line-continuation

--- a/test/specs/issues/030.cpp.yaml
+++ b/test/specs/issues/030.cpp.yaml
@@ -50,7 +50,6 @@
     - punctuation.definition.parameters.begin
 - source: ...
   scopes:
-    - ellipses
     - punctuation.vararg-ellipses.variable.parameter.preprocessor
 - source: )
   scopes:

--- a/test/specs/issues/034.c.yaml
+++ b/test/specs/issues/034.c.yaml
@@ -22,8 +22,6 @@
 - source: (
   scopes:
     - punctuation.section.parens.begin.bracket.round
-  scopesEnd:
-    - meta.preprocessor.macro
 - source: /*
   scopesBegin:
     - comment.block
@@ -36,16 +34,12 @@
   scopesEnd:
     - comment.block
 - source: (
-  scopesBegin:
-    - meta.parens
   scopes:
     - punctuation.section.parens.begin.bracket.round
 - source: addr
 - source: )
   scopes:
     - punctuation.section.parens.end.bracket.round
-  scopesEnd:
-    - meta.parens
 - source: <
   scopes:
     - keyword.operator.comparison
@@ -53,4 +47,7 @@
 - source: +
   scopes:
     - keyword.operator
-- source: ' UPGRADE_SPACE_SIZE)'
+- source: ' UPGRADE_SPACE_SIZE'
+- source: )
+  scopes:
+    - punctuation.section.parens.end.bracket.round

--- a/test/specs/issues/136.cpp.yaml
+++ b/test/specs/issues/136.cpp.yaml
@@ -79,13 +79,13 @@
   scopes:
     - punctuation.definition.parameters.begin
 - source: expected
-  scopesBegin:
+  scopes:
     - variable.parameter.preprocessor
 - source: ','
   scopes:
     - punctuation.separator.parameters
-- source: ' actual'
-  scopesEnd:
+- source: actual
+  scopes:
     - variable.parameter.preprocessor
 - source: )
   scopes:

--- a/test/specs/issues/324.cpp.yaml
+++ b/test/specs/issues/324.cpp.yaml
@@ -1,0 +1,238 @@
+- source: '#'
+  scopesBegin:
+    - meta.preprocessor.macro
+    - keyword.control.directive.define
+  scopes:
+    - punctuation.definition.directive
+- source: define
+  scopesEnd:
+    - keyword.control.directive.define
+- source: HARVEST_REQUEST_PARAM_APPEND
+  scopes:
+    - entity.name.function.preprocessor
+- source: (
+  scopes:
+    - punctuation.definition.parameters.begin
+- source: string
+  scopes:
+    - variable.parameter.preprocessor
+- source: ','
+  scopes:
+    - punctuation.separator.parameters
+- source: key
+  scopes:
+    - variable.parameter.preprocessor
+- source: ','
+  scopes:
+    - punctuation.separator.parameters
+- source: value
+  scopes:
+    - variable.parameter.preprocessor
+- source: ','
+  scopes:
+    - punctuation.separator.parameters
+- source: edited
+  scopes:
+    - variable.parameter.preprocessor
+- source: ','
+  scopes:
+    - punctuation.separator.parameters
+- source: ampersand
+  scopes:
+    - variable.parameter.preprocessor
+- source: )
+  scopes:
+    - punctuation.definition.parameters.end
+- source: \
+  scopes:
+    - constant.character.escape.line-continuation
+- source: do
+  scopes:
+    - keyword.control.do
+- source: '{'
+  scopesBegin:
+    - meta.block
+  scopes:
+    - punctuation.section.block.begin.bracket.curly
+- source: \
+  scopes:
+    - constant.character.escape.line-continuation
+  scopesEnd:
+    - meta.block
+- source: (
+  scopesBegin:
+    - meta.parens
+  scopes:
+    - punctuation.section.parens.begin.bracket.round
+- source: if
+  scopes:
+    - keyword.control.if
+- source: (
+  scopesBegin:
+    - meta.parens
+  scopes:
+    - punctuation.section.parens.begin.bracket.round
+- source: edited
+- source: )
+  scopes:
+    - punctuation.section.parens.end.bracket.round
+  scopesEnd:
+    - meta.parens
+- source: ' {                                                       '
+- source: \
+  scopes:
+    - constant.character.escape.line-continuation
+- source: if
+  scopes:
+    - keyword.control.if
+- source: (
+  scopesBegin:
+    - meta.parens
+  scopes:
+    - punctuation.section.parens.begin.bracket.round
+- source: ampersand
+- source: )
+  scopes:
+    - punctuation.section.parens.end.bracket.round
+  scopesEnd:
+    - meta.parens
+- source: ' {                                               '
+- source: \
+  scopes:
+    - constant.character.escape.line-continuation
+- source: g_string_append_printf
+  scopes:
+    - entity.name.function.call
+- source: (
+  scopes:
+    - punctuation.section.arguments.begin.bracket.round.function.call
+- source: string
+- source: ','
+  scopes:
+    - punctuation.separator.delimiter.comma
+- source: '"'
+  scopesBegin:
+    - string.quoted.double
+  scopes:
+    - punctuation.definition.string.begin
+- source: '&'
+- source: '%s'
+  scopes:
+    - constant.other.placeholder
+- source: =
+- source: '%s'
+  scopes:
+    - constant.other.placeholder
+- source: '"'
+  scopes:
+    - punctuation.definition.string.end
+  scopesEnd:
+    - string.quoted.double
+- source: ','
+  scopes:
+    - punctuation.separator.delimiter.comma
+- source: ' #key'
+- source: ','
+  scopes:
+    - punctuation.separator.delimiter.comma
+- source: ' #value'
+- source: )
+  scopes:
+    - punctuation.section.arguments.end.bracket.round.function.call
+- source: ;
+  scopes:
+    - punctuation.terminator.statement
+- source: \
+  scopes:
+    - constant.character.escape.line-continuation
+- source: "\t\t\t}"
+- source: else
+  scopes:
+    - keyword.control.else
+- source: ' {                                                      '
+- source: \
+  scopes:
+    - constant.character.escape.line-continuation
+- source: "\t\t\t\tampersand "
+- source: =
+  scopes:
+    - keyword.operator.assignment
+- source: ' TRUE'
+- source: ;
+  scopes:
+    - punctuation.terminator.statement
+- source: \
+  scopes:
+    - constant.character.escape.line-continuation
+- source: g_string_append_printf
+  scopes:
+    - entity.name.function.call
+- source: (
+  scopes:
+    - punctuation.section.arguments.begin.bracket.round.function.call
+- source: string
+- source: ','
+  scopes:
+    - punctuation.separator.delimiter.comma
+- source: '"'
+  scopesBegin:
+    - string.quoted.double
+  scopes:
+    - punctuation.definition.string.begin
+- source: '%s'
+  scopes:
+    - constant.other.placeholder
+- source: =
+- source: '%s'
+  scopes:
+    - constant.other.placeholder
+- source: '"'
+  scopes:
+    - punctuation.definition.string.end
+  scopesEnd:
+    - string.quoted.double
+- source: ','
+  scopes:
+    - punctuation.separator.delimiter.comma
+- source: ' #key'
+- source: ','
+  scopes:
+    - punctuation.separator.delimiter.comma
+- source: ' #value'
+- source: )
+  scopes:
+    - punctuation.section.arguments.end.bracket.round.function.call
+- source: ;
+  scopes:
+    - punctuation.terminator.statement
+- source: \
+  scopes:
+    - constant.character.escape.line-continuation
+- source: "\t\t\t}                                                             "
+- source: \
+  scopes:
+    - constant.character.escape.line-continuation
+- source: "\t\t}"
+- source: )
+  scopes:
+    - punctuation.section.parens.end.bracket.round
+  scopesEnd:
+    - meta.parens
+- source: \
+  scopes:
+    - constant.character.escape.line-continuation
+- source: "\t}"
+- source: while
+  scopes:
+    - keyword.control.while
+- source: (
+  scopesBegin:
+    - meta.parens
+  scopes:
+    - punctuation.section.parens.begin.bracket.round
+- source: '0'
+  scopes:
+    - constant.numeric.decimal
+- source: )
+  scopes:
+    - punctuation.section.parens.end.bracket.round

--- a/test/specs/issues/324.cpp.yaml
+++ b/test/specs/issues/324.cpp.yaml
@@ -96,7 +96,7 @@
     - punctuation.section.parens.end.bracket.round
   scopesEnd:
     - meta.parens
-- source: ' {                                               '
+- source: ' {                                                 '
 - source: \
   scopes:
     - constant.character.escape.line-continuation
@@ -149,7 +149,7 @@
 - source: else
   scopes:
     - keyword.control.else
-- source: ' {                                                      '
+- source: ' {                                                        '
 - source: \
   scopes:
     - constant.character.escape.line-continuation
@@ -208,7 +208,7 @@
 - source: \
   scopes:
     - constant.character.escape.line-continuation
-- source: "\t\t\t}                                                             "
+- source: "\t\t\t}                                                               "
 - source: \
   scopes:
     - constant.character.escape.line-continuation

--- a/test/specs/vscode/example.cpp.yaml
+++ b/test/specs/vscode/example.cpp.yaml
@@ -4746,7 +4746,6 @@
     - storage.type.template
 - source: ...
   scopes:
-    - ellipses
     - punctuation.vararg-ellipses.template.definition
 - source: Args
   scopes:

--- a/test/specs/vscode/misc005.cpp.yaml
+++ b/test/specs/vscode/misc005.cpp.yaml
@@ -2890,7 +2890,6 @@
     - storage.type.template
 - source: ...
   scopes:
-    - ellipses
     - punctuation.vararg-ellipses.template.definition
 - source: Args
   scopes:

--- a/test/specs/vscode/misc005.cpp.yaml
+++ b/test/specs/vscode/misc005.cpp.yaml
@@ -29607,13 +29607,13 @@
   scopes:
     - punctuation.definition.parameters.begin
 - source: FUNC
-  scopesBegin:
+  scopes:
     - variable.parameter.preprocessor
 - source: ','
   scopes:
     - punctuation.separator.parameters
-- source: ' ARG'
-  scopesEnd:
+- source: ARG
+  scopes:
     - variable.parameter.preprocessor
 - source: )
   scopes:


### PR DESCRIPTION
Fixes #324.

This does not implement multi-line macro argument definitions as described in https://github.com/jeff-hykin/cpp-textmate-grammar/issues/324#issuecomment-514722502