### PR TITLE
Fix early bailout, line numbers, support glob patterns

### DIFF
--- a/test/source/commands/report.js
+++ b/test/source/commands/report.js
@@ -1,48 +1,52 @@
-const fs = require("fs")
-const glob = require("glob")
-const path = require("path")
-const _ = require("lodash")
+const fs = require("fs");
+const glob = require("glob");
+const path = require("path");
+const _ = require("lodash");
 
-const getTokens = require("../get_tokens")
-const argv = require("../arguments")
-const { getOniguruma } = require("../report/oniguruma_decorator")
-const { getRegistry } = require("../registry")
-const recorder = require("../report/recorder")
-const {performanceForEachFixture, currentActiveFixture} = require("../symbols")
+const getTokens = require("../get_tokens");
+const argv = require("../arguments");
+const { getOniguruma } = require("../report/oniguruma_decorator");
+const { getRegistry } = require("../registry");
+const recorder = require("../report/recorder");
+const {
+    performanceForEachFixture,
+    currentActiveFixture
+} = require("../symbols");
 
-const registry = getRegistry(getOniguruma)
+const registry = getRegistry(getOniguruma);
 // get all reporters
-let reporters = {}
+let reporters = {};
 for (const each of glob.sync(`${__dirname}/../report/reporters/*.js`)) {
-    let filename = path.basename(each).replace(/\.js$/, "")
-    reporters[filename] = require(each)
+    let filename = path.basename(each).replace(/\.js$/, "");
+    reporters[filename] = require(each);
 }
 
 //
 // Commandline args
 //
-let [reporterName, ...files] = argv._
+let [reporterName, ...files] = argv._;
 
 // load the one mentioned in the commandline
-recorder.loadReporter(reporters[reporterName])
+recorder.loadReporter(reporters[reporterName]);
 // if no files mentioned, then use all the fixtures
 if (files.length === 0) {
     // use text fixtures instead
-    files = require("../get_tests")().map(test => test.fixture)
+    files = require("../get_tests")().map(test => test.fixture);
 }
 
-collectRecords()
+files = _.flatten(files.map(file => glob.sync(file)));
+collectRecords();
 async function collectRecords() {
-    global[performanceForEachFixture] = {}
+    global[performanceForEachFixture] = {};
     for (const eachFile of files) {
-        console.log(eachFile)
-        global[currentActiveFixture] = eachFile
+        console.log(eachFile);
+        global[currentActiveFixture] = eachFile;
         const fixture = fs
             .readFileSync(eachFile)
             .toString()
-            .split("\n")
-        await getTokens(registry, eachFile, fixture, false, () => true)
+            .split("\n");
+        await getTokens(registry, eachFile, fixture, false, () => true);
     }
     console.log();
-    recorder.reportAllRecorders()
+    recorder.reportAllRecorders();
 }

--- a/test/source/report/onig_scanner.js
+++ b/test/source/report/onig_scanner.js
@@ -45,7 +45,7 @@ module.exports = class OnigScanner {
             } catch (e) {
                 console.log(this.patterns[index]);
             }
-            if (match[0].start == startPosition) {
+            if (match && match[0].start == startPosition) {
                 break;
             }
         }

--- a/test/source/report/rewrite_grammar.js
+++ b/test/source/report/rewrite_grammar.js
@@ -11,22 +11,22 @@ const recorder = require("./recorder");
 function rewriteRule(rule, jsonPointer, pointers, scopeName) {
     if (rule.match) {
         rule.match = `(?#${scopeName}:${
-            pointers[jsonPointer + "/match"].key.line
+            pointers[jsonPointer + "/match"].key.line + 1
         })${rule.match}`;
     }
     if (rule.begin) {
         rule.begin = `(?#${scopeName}:${
-            pointers[jsonPointer + "/begin"].key.line
+            pointers[jsonPointer + "/begin"].key.line + 1
         })${rule.begin}`;
     }
     if (rule.end) {
         rule.end = `(?#${scopeName}:${
-            pointers[jsonPointer + "/end"].key.line
+            pointers[jsonPointer + "/end"].key.line + 1
         })${rule.end}`;
     }
     if (rule.while) {
         rule.while = `(?#${scopeName}:${
-            pointers[jsonPointer + "/while"].key.line
+            pointers[jsonPointer + "/while"].key.line + 1
         })${rule.while}`;
     }
     if (rule.patterns) {


### PR DESCRIPTION
The early bailout addition assumed a match. This resulted in the reporting tools to not work.

Line numbers in reports have 1 added to them to account for the fact that in text editors number starts at 1.

The perf tools now parse their arguments as a glob pattern rather than individual files.