### PR TITLE
Rewrite test suite to use yarg commands for dispatch

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,3 +6,6 @@ indent_size = 4
 charset = utf-8
 trim_trailing_whitespace = false
 insert_final_newline = false
+
+[package.json]
+indent_size = 2

--- a/package.json
+++ b/package.json
@@ -10,18 +10,18 @@
     "prelint": "npm run build",
     "lint": "ruby scripts/lint.rb",
     "pretest": "npm run build",
-    "test": "node test/source/commands/test.js",
+    "test": "node test/source/index.js test",
     "testall": "npm test -- --all",
     "genall": "npm run generate-specs -- --all",
     "preversion": "npm test",
     "version": "npm run build && git add -A syntaxes",
     "pregenerate-specs": "npm run build",
-    "generate-specs": "node test/source/commands/generate-specs.js",
+    "generate-specs": "node test/source/index.js generate-specs",
     "gen": "npm run generate-specs -- ",
     "try": "npm run test -- --show-failure-only",
-    "sort-specs": "node test/source/commands/sort-specs.js",
+    "sort-specs": "node test/source/index.js sort-specs",
     "prereport": "npm run build",
-    "report": "node test/source/commands/report",
+    "report": "node test/source/index.js report",
     "perf": "npm run report -- perf",
     "cov": "npm run report -- coverage",
     "publish": "ruby scripts/publish.rb"
@@ -110,6 +110,5 @@
     "vscode-textmate-experimental": "^4.1.1",
     "yargs": "^13.2.2"
   },
-  "dependencies": {
-  }
+  "dependencies": {}
 }

--- a/test/source/arguments.js
+++ b/test/source/arguments.js
@@ -1,33 +1,42 @@
-module.exports = require("yargs")
-    .usage("Usage: $0 [options] [fixture]")
-    .wrap(require("yargs").terminalWidth())
-    .demandCommand(0)
-    // --color is parsed by chalk
-    .option("color", {
-        default: true,
-        describe: "enable color",
-        type: "boolean"
-    })
-    .nargs("color", 0)
-    .option("all", {
-        default: false,
-        describe: "run for all fixtures",
-        type: "boolean"
-    })
-    .option("show-failure-only", {
-        default: false,
-        describe: "Only show IF a spec failed, no details",
-        type: "boolean"
-    })
-    .option("header-c", {
-        default: false,
-        type: "boolean",
-        describe: "treat .h as source.c"
-    })
-    .option("perf-limit", {
-        default: 20,
-        type: "number",
-        describe: "limit the number of perf report lines (0 to disable)"
-    })
-    .strict()
-    .example("$0 issues/002.cpp").argv;
+const yargs = require("yargs");
+let argv = null;
+
+function parseArgs() {
+    argv = yargs
+        //.scriptName("test/index.js")
+        .wrap(yargs.terminalWidth())
+        .commandDir("commands")
+        // --color is parsed by chalk
+        .option("color", {
+            default: true,
+            describe: "enable color",
+            type: "boolean",
+            global: true
+        })
+        .nargs("color", 0)
+        .option("all", {
+            default: false,
+            describe: "run for all fixtures",
+            type: "boolean",
+            global: true
+        })
+        .option("header-c", {
+            default: false,
+            type: "boolean",
+            describe:
+                "treat .h as source.c (vscode by default treats .h files as source.cpp)",
+            global: true
+        })
+        .strict()
+        .example("$0 issues/002.cpp").argv;
+}
+
+module.exports = {
+    getArgs: () => {
+        if (argv === null) {
+            parseArgs();
+        }
+        return argv;
+    },
+    parseArgs: parseArgs
+};

--- a/test/source/commands/generate-specs.js
+++ b/test/source/commands/generate-specs.js
@@ -4,21 +4,19 @@ const path = require("path");
 const fs = require("fs");
 const yaml = require("js-yaml");
 
-const argv = require("../arguments");
 const generateSpec = require("../generate_spec");
 const pathFor = require("../paths");
 
-const tests = require("../get_tests")(test => {
-    const result =
-        (!fs.existsSync(test.spec.yaml) && !fs.existsSync(test.spec.json)) ||
-        argv.all ||
-        argv._.length !== 0;
-    return result;
-});
+async function generateSpecs(yargs) {
+    const tests = require("../get_tests")(yargs, test => {
+        const result =
+            (!fs.existsSync(test.spec.yaml) &&
+                !fs.existsSync(test.spec.json)) ||
+            yargs.all ||
+            yargs.fixtures.length !== 0;
+        return result;
+    });
 
-// and generate the specs
-generateSpecs();
-async function generateSpecs() {
     for (const test of tests) {
         console.log(
             "generating spec for",
@@ -43,3 +41,15 @@ function keyCompare(key1, key2) {
     const order = ["source", "scopesBegin", "scopes", "scopesEnd"];
     return order.indexOf(key1) - order.indexOf(key2);
 }
+
+module.exports = {
+    command: "generate-specs [fixtures..]",
+    desc: "(re)generate spec files",
+    builder: yargs => {
+        yargs.positional("fixtures", {
+            default: [],
+            describe: "the fixtures to use"
+        });
+    },
+    handler: yargs => generateSpecs(yargs)
+};

--- a/test/source/commands/report.js
+++ b/test/source/commands/report.js
@@ -1,48 +1,52 @@
-const fs = require("fs")
-const glob = require("glob")
-const path = require("path")
-const _ = require("lodash")
+const fs = require("fs");
+const glob = require("glob");
+const path = require("path");
+const _ = require("lodash");
 
-const getTokens = require("../get_tokens")
-const argv = require("../arguments")
-const { getOniguruma } = require("../report/oniguruma_decorator")
-const { getRegistry } = require("../registry")
-const recorder = require("../report/recorder")
-const {performanceForEachFixture, currentActiveFixture} = require("../symbols")
+const getTokens = require("../get_tokens");
+const argv = require("../arguments");
+const { getOniguruma } = require("../report/oniguruma_decorator");
+const { getRegistry } = require("../registry");
+const recorder = require("../report/recorder");
+const {
+    performanceForEachFixture,
+    currentActiveFixture
+} = require("../symbols");
 
-const registry = getRegistry(getOniguruma)
+const registry = getRegistry(getOniguruma);
 // get all reporters
-let reporters = {}
+let reporters = {};
 for (const each of glob.sync(`${__dirname}/../report/reporters/*.js`)) {
-    let filename = path.basename(each).replace(/\.js$/, "")
-    reporters[filename] = require(each)
+    let filename = path.basename(each).replace(/\.js$/, "");
+    reporters[filename] = require(each);
 }
 
 //
 // Commandline args
 //
-let [reporterName, ...files] = argv._
+let [reporterName, ...files] = argv._;
 
 // load the one mentioned in the commandline
-recorder.loadReporter(reporters[reporterName])
+recorder.loadReporter(reporters[reporterName]);
 // if no files mentioned, then use all the fixtures
 if (files.length === 0) {
     // use text fixtures instead
-    files = require("../get_tests")().map(test => test.fixture)
+    files = require("../get_tests")().map(test => test.fixture);
 }
 
-collectRecords()
+files = _.flatten(files.map(file => glob.sync(file)));
+collectRecords();
 async function collectRecords() {
-    global[performanceForEachFixture] = {}
+    global[performanceForEachFixture] = {};
     for (const eachFile of files) {
-        console.log(eachFile)
-        global[currentActiveFixture] = eachFile
+        console.log(eachFile);
+        global[currentActiveFixture] = eachFile;
         const fixture = fs
             .readFileSync(eachFile)
             .toString()
-            .split("\n")
-        await getTokens(registry, eachFile, fixture, false, () => true)
+            .split("\n");
+        await getTokens(registry, eachFile, fixture, false, () => true);
     }
     console.log();
-    recorder.reportAllRecorders()
+    recorder.reportAllRecorders();
 }

--- a/test/source/commands/report.js
+++ b/test/source/commands/report.js
@@ -4,7 +4,6 @@ const path = require("path");
 const _ = require("lodash");
 
 const getTokens = require("../get_tokens");
-const argv = require("../arguments");
 const { getOniguruma } = require("../report/oniguruma_decorator");
 const { getRegistry } = require("../registry");
 const recorder = require("../report/recorder");
@@ -13,7 +12,6 @@ const {
     currentActiveFixture
 } = require("../symbols");
 
-const registry = getRegistry(getOniguruma);
 // get all reporters
 let reporters = {};
 for (const each of glob.sync(`${__dirname}/../report/reporters/*.js`)) {
@@ -21,22 +19,20 @@ for (const each of glob.sync(`${__dirname}/../report/reporters/*.js`)) {
     reporters[filename] = require(each);
 }
 
-//
-// Commandline args
-//
-let [reporterName, ...files] = argv._;
+async function runReport(yargs) {
+    const registry = getRegistry(getOniguruma);
+    // load the one mentioned in the commandline
+    recorder.loadReporter(reporters[yargs.reporter]);
 
-// load the one mentioned in the commandline
-recorder.loadReporter(reporters[reporterName]);
-// if no files mentioned, then use all the fixtures
-if (files.length === 0) {
-    // use text fixtures instead
-    files = require("../get_tests")().map(test => test.fixture);
-}
+    // if no files mentioned, then use all the fixtures
+    let files = yargs.fixtures;
+    if (files.length === 0) {
+        // use text fixtures instead
+        files = require("../get_tests")(yargs).map(test => test.fixture);
+    } else {
+        files = _.flatten(files.map(file => glob.sync(file)));
+    }
 
-files = _.flatten(files.map(file => glob.sync(file)));
-collectRecords();
-async function collectRecords() {
     global[performanceForEachFixture] = {};
     for (const eachFile of files) {
         console.log(eachFile);
@@ -50,3 +46,25 @@ async function collectRecords() {
     console.log();
     recorder.reportAllRecorders();
 }
+
+module.exports = {
+    command: "report <reporter> [fixtures..]",
+    desc: "Runs <reporter> and reports the collected information.",
+    builder: yargs => {
+        yargs
+            .positional("reporter", {
+                choices: Object.keys(reporters),
+                describe: "the reporter to run"
+            })
+            .positional("fixtures", {
+                default: [],
+                describe: "the fixtures to use"
+            })
+            .option("perf-limit", {
+                default: 20,
+                type: "number",
+                describe: "limit the number of perf report lines (0 to disable)"
+            });
+    },
+    handler: yargs => runReport(yargs)
+};

--- a/test/source/commands/sort-specs.js
+++ b/test/source/commands/sort-specs.js
@@ -6,19 +6,17 @@ const path = require("path");
 const fs = require("fs");
 const yaml = require("js-yaml");
 
-const argv = require("../arguments");
 const pathFor = require("../paths");
 
-const tests = require("../get_tests")(test => {
-    const result =
-        fs.existsSync(test.spec.yaml) ||
-        fs.existsSync(test.spec.json) ||
-        argv._.length !== 0;
-    return result;
-});
+async function sortSpecs(yargs) {
+    const tests = require("../get_tests")(yargs, test => {
+        const result =
+            fs.existsSync(test.spec.yaml) ||
+            fs.existsSync(test.spec.json) ||
+            yargs.fixtures.length !== 0;
+        return result;
+    });
 
-sortSpecs();
-async function sortSpecs() {
     for (const test of tests) {
         console.log(
             "sorting spec for",
@@ -39,3 +37,9 @@ function keyCompare(key1, key2) {
     const order = ["source", "scopesBegin", "scopes", "scopesEnd"];
     return order.indexOf(key1) - order.indexOf(key2);
 }
+
+module.exports = {
+    command: "sort-specs [fixtures..]",
+    desc: "sort spec files",
+    handler: yargs => sortSpecs(yargs)
+};

--- a/test/source/get_tests.js
+++ b/test/source/get_tests.js
@@ -1,27 +1,36 @@
-const path = require("path")
-const glob = require("glob")
-const fs = require("fs")
+const path = require("path");
+const glob = require("glob");
+const fs = require("fs");
 
-const argv = require("./arguments")
-const pathFor = require("./paths")
+const pathFor = require("./paths");
 
 /**
  * @typedef {{fixture: string, spec: {json: string, yaml: string, default: string}}} Test
  * @param {(test: Test) => boolean} predicate
  * @returns {Test[]}
  */
-module.exports = (testFilter = each => true) =>
+module.exports = (yargs, testFilter = _each => true) =>
     pathFor.eachFixture
         .map(fixture => {
-            let specPath = fixture.replace(pathFor.fixtures, pathFor.specDir)
+            console.log(fixture);
+            let specPath = fixture.replace(pathFor.fixtures, pathFor.specDir);
             return {
                 fixture,
                 spec: {
                     json: `${specPath}.json`,
                     yaml: `${specPath}.yaml`,
                     // use json if yaml doesn't exist
-                    default: fs.existsSync(`${specPath}.yaml`) ? `${specPath}.yaml` : `${specPath}.yaml`,
-                },
-            }
+                    default: fs.existsSync(`${specPath}.yaml`)
+                        ? `${specPath}.yaml`
+                        : `${specPath}.yaml`
+                }
+            };
         })
-        .filter(test => testFilter(test) && (argv._.length == 0 || argv._.includes(path.relative(pathFor.fixtures, test.fixture))))
+        .filter(
+            test =>
+                testFilter(test) &&
+                (yargs.fixtures.length == 0 ||
+                    yargs.fixtures.includes(
+                        path.relative(pathFor.fixtures, test.fixture)
+                    ))
+        );

--- a/test/source/get_tokens.js
+++ b/test/source/get_tokens.js
@@ -2,21 +2,19 @@
 const path = require("path");
 const chalk = require("chalk");
 const vsctm = require("vscode-textmate-experimental");
-const argv = require("yargs").argv;
 const paths = require("./paths");
 const fs = require("fs");
 
-
 // retrive all the filetypes from the syntax
-let extensionsFor = {}
+let extensionsFor = {};
 for (let eachSyntaxPath of paths["eachJsonSyntax"]) {
-    let langExtension = path.basename(eachSyntaxPath).replace(/\..+/g,"")
-    let syntax = JSON.parse(fs.readFileSync(eachSyntaxPath))
-    extensionsFor[langExtension] = syntax["fileTypes"]
+    let langExtension = path.basename(eachSyntaxPath).replace(/\..+/g, "");
+    let syntax = JSON.parse(fs.readFileSync(eachSyntaxPath));
+    extensionsFor[langExtension] = syntax["fileTypes"];
 }
 
-let languageExtensionFor = (fixturePath) => {
-    let fixtureExtension = path.extname(fixturePath).replace(/\./,"");
+let languageExtensionFor = fixturePath => {
+    let fixtureExtension = path.extname(fixturePath).replace(/\./, "");
     let matchingLanguageExtension = null;
     // find which lang the extension belongs to
     for (let eachLangExtension of Object.keys(extensionsFor)) {
@@ -24,14 +22,16 @@ let languageExtensionFor = (fixturePath) => {
         if (fixturePath.includes(`/${eachLangExtension}/`)) {
             matchingLanguageExtension = eachLangExtension;
             break;
-        // if the language extension is in their list, then there
-        } else if (extensionsFor[eachLangExtension].includes(fixtureExtension)) {
+            // if the language extension is in their list, then there
+        } else if (
+            extensionsFor[eachLangExtension].includes(fixtureExtension)
+        ) {
             matchingLanguageExtension = eachLangExtension;
             break;
         }
     }
     return matchingLanguageExtension;
-}
+};
 
 /**
  * @param {vsctm.Registry} registry
@@ -40,11 +40,19 @@ let languageExtensionFor = (fixturePath) => {
  * @param {boolean} showFailureOnly
  * @param {(line: string, token: vsctm.IToken) => boolean} process
  */
-module.exports = async function(registry, fixturePath, fixture, showFailureOnly, process) {
+module.exports = async function(
+    registry,
+    fixturePath,
+    fixture,
+    showFailureOnly,
+    process
+) {
     let displayedAtLeastOnce = false;
     let returnValue = true;
     try {
-        const grammar = await registry.loadGrammar(`source.${languageExtensionFor(fixturePath)}`);
+        const grammar = await registry.loadGrammar(
+            `source.${languageExtensionFor(fixturePath)}`
+        );
         let ruleStack = null;
         let lineNumber = 1;
         for (const line of fixture) {
@@ -58,7 +66,13 @@ module.exports = async function(registry, fixturePath, fixture, showFailureOnly,
                 }
             }
             if (displayLine) {
-                showFailureOnly || console.log("line was:\n  %s:%d: |%s|", fixturePath, lineNumber, line);
+                showFailureOnly ||
+                    console.log(
+                        "line was:\n  %s:%d: |%s|",
+                        fixturePath,
+                        lineNumber,
+                        line
+                    );
                 displayedAtLeastOnce = true;
             }
             lineNumber += 1;
@@ -68,7 +82,7 @@ module.exports = async function(registry, fixturePath, fixture, showFailureOnly,
         returnValue = false;
     }
     if (displayedAtLeastOnce) {
-        console.log(chalk.redBright("   Failed"))
+        console.log(chalk.redBright("   Failed"));
     }
 
     return returnValue;

--- a/test/source/index.js
+++ b/test/source/index.js
@@ -1,0 +1,4 @@
+const argv = require("./arguments");
+argv.parseArgs();
+
+// purposely blank, the command dispatch is done with yargs

--- a/test/source/report/onig_scanner.js
+++ b/test/source/report/onig_scanner.js
@@ -45,7 +45,7 @@ module.exports = class OnigScanner {
             } catch (e) {
                 console.log(this.patterns[index]);
             }
-            if (match[0].start == startPosition) {
+            if (match && match[0].start == startPosition) {
                 break;
             }
         }

--- a/test/source/report/recorder.js
+++ b/test/source/report/recorder.js
@@ -19,7 +19,8 @@ class recorder {
         this.empty = true;
         for (const pointer of Object.keys(pointers)) {
             if (/(?:match|begin|end|while)$/.test(pointer)) {
-                const source = scopeName + ":" + pointers[pointer].key.line;
+                const source =
+                    scopeName + ":" + (pointers[pointer].key.line + 1);
                 this.coverage[source] = {
                     source,
                     // order is failure, unchosen, chosen

--- a/test/source/report/reporters/perf.js
+++ b/test/source/report/reporters/perf.js
@@ -24,7 +24,7 @@ module.exports = function(scopeName, coverage) {
             keys,
             k => coverage[k].sumTime[i] / coverage[k].count[i]
         );
-        keys = _.take(keys, argv["perf-limit"]);
+        keys = _.take(keys, argv.getArgs()["perf-limit"]);
         const totalMax = _.maxBy(keys, k => coverage[k].sumTime[i]);
         for (const k of keys) {
             let color =

--- a/test/source/report/reporters/perf2.js
+++ b/test/source/report/reporters/perf2.js
@@ -2,55 +2,61 @@ const _ = require("lodash");
 const fs = require("fs");
 const path = require("path");
 const chalk = require("chalk");
-const argv = require("../../arguments");
-const {performanceForEachFixture, currentActiveFixture} = require("../../symbols");
+const {
+    performanceForEachFixture,
+    currentActiveFixture
+} = require("../../symbols");
 
 const labels = ["match failure", "matched, not chosen", "matched, chosen"];
 
 module.exports = function(scopeName, coverage) {
     for (let i = 0; i < 3; i += 1) {
-        let allScopes = []
+        let allScopes = [];
         for (const k of Object.keys(coverage)) {
             if (k => coverage[k].count[i] > 0 && coverage[k].sumTime[i] > 0) {
                 allScopes.push({
                     source: coverage[k].source,
                     average: coverage[k].sumTime[i] / coverage[k].count[i],
-                    total: coverage[k].sumTime[i],
-                })
+                    total: coverage[k].sumTime[i]
+                });
             }
         }
 
         // get the info for the current fixture
-        let currentFixtureRecord = global[performanceForEachFixture][global[currentActiveFixture]]
+        let currentFixtureRecord =
+            global[performanceForEachFixture][global[currentActiveFixture]];
         if (!(currentFixtureRecord instanceof Object)) {
             currentFixtureRecord = {
                 maxAverageTime: 0,
                 maxTotalTime: 0,
                 maxAverageSource: "",
-                maxTotalSource: "",
-            }
+                maxTotalSource: ""
+            };
         }
         // update the scope if they're larger
         for (const each of allScopes) {
             if (currentFixtureRecord.maxAverageTime < each.average) {
-                currentFixtureRecord.maxAverageSource = each.source
-                currentFixtureRecord.maxAverageTime = each.average
+                currentFixtureRecord.maxAverageSource = each.source;
+                currentFixtureRecord.maxAverageTime = each.average;
             }
             if (currentFixtureRecord.maxTotalTime < each.total) {
-                currentFixtureRecord.maxTotalSource = each.source
-                currentFixtureRecord.maxTotalTime = each.total
+                currentFixtureRecord.maxTotalSource = each.source;
+                currentFixtureRecord.maxTotalTime = each.total;
             }
         }
         // record the performance
-        global[performanceForEachFixture][global[currentActiveFixture]] = currentFixtureRecord
+        global[performanceForEachFixture][
+            global[currentActiveFixture]
+        ] = currentFixtureRecord;
     }
-    // 
+    //
     // Save the report
-    // 
-    let report = JSON.parse(fs.readFileSync("report.json", "utf-8"))
-    let name = path.basename(global[currentActiveFixture])
-    let folder = path.dirname(global[currentActiveFixture])
-    let folderName = path.basename(folder)
-    report[folderName+"/"+name] = global[performanceForEachFixture][global[currentActiveFixture]]
-    fs.writeFileSync("report.json",JSON.stringify(report))
+    //
+    let report = JSON.parse(fs.readFileSync("report.json", "utf-8"));
+    let name = path.basename(global[currentActiveFixture]);
+    let folder = path.dirname(global[currentActiveFixture]);
+    let folderName = path.basename(folder);
+    report[folderName + "/" + name] =
+        global[performanceForEachFixture][global[currentActiveFixture]];
+    fs.writeFileSync("report.json", JSON.stringify(report));
 };

--- a/test/source/report/rewrite_grammar.js
+++ b/test/source/report/rewrite_grammar.js
@@ -11,22 +11,22 @@ const recorder = require("./recorder");
 function rewriteRule(rule, jsonPointer, pointers, scopeName) {
     if (rule.match) {
         rule.match = `(?#${scopeName}:${
-            pointers[jsonPointer + "/match"].key.line
+            pointers[jsonPointer + "/match"].key.line + 1
         })${rule.match}`;
     }
     if (rule.begin) {
         rule.begin = `(?#${scopeName}:${
-            pointers[jsonPointer + "/begin"].key.line
+            pointers[jsonPointer + "/begin"].key.line + 1
         })${rule.begin}`;
     }
     if (rule.end) {
         rule.end = `(?#${scopeName}:${
-            pointers[jsonPointer + "/end"].key.line
+            pointers[jsonPointer + "/end"].key.line + 1
         })${rule.end}`;
     }
     if (rule.while) {
         rule.while = `(?#${scopeName}:${
-            pointers[jsonPointer + "/while"].key.line
+            pointers[jsonPointer + "/while"].key.line + 1
         })${rule.while}`;
     }
     if (rule.patterns) {

--- a/test/source/select_tests.js
+++ b/test/source/select_tests.js
@@ -2,14 +2,13 @@ const fs = require("fs");
 const { execSync } = require("child_process");
 const path = require("path");
 
-const argv = require("./arguments");
 const pathFor = require("./paths");
 
 const defaultTest = test =>
     fs.existsSync(test.spec.yaml) || !fs.existsSync(test.spec.json);
 
-module.exports = function() {
-    if (argv._.length !== 0 || argv.all) {
+module.exports = function(yargs) {
+    if (yargs.fixtures.length !== 0 || yargs.all) {
         return defaultTest;
     }
     const status = execSync("git status --porcelain").toString();


### PR DESCRIPTION
This change is motivated by the fact that running a reporter on the default fixtures is currently impossible. This was because the reporter choice was a positional argument, therefore the number of positional arguments is never zero when using the reporting feature. Many functions had code to the effect of `argv._.length === 0 || _.include(argv._,fixture)` as a way of filtering fixtures. This prevented positional arguments from being used for non-filtering purposes.

This rewrite has each command register the arguments it takes, this way tools can just look for the `yargs.fixture` to determine how to filter fixtures.

Additionally, the help menu no longer shows options (like `--perf-limit`) that are not relevant to the requested command.