### PR TITLE
Display current line number when making reports

### DIFF
--- a/test/source/commands/report.js
+++ b/test/source/commands/report.js
@@ -41,7 +41,7 @@ async function runReport(yargs) {
             .readFileSync(eachFile)
             .toString()
             .split("\n");
-        await getTokens(registry, eachFile, fixture, false, () => true);
+        await getTokens(registry, eachFile, fixture, false, true, () => true);
     }
     console.log();
     recorder.reportAllRecorders();

--- a/test/source/generate_spec.js
+++ b/test/source/generate_spec.js
@@ -11,7 +11,7 @@ const { removeScopeName } = require("./utils");
  */
 module.exports = async function generateSpec(path, fixture) {
     let spec = [];
-    await getTokens(registry, path, fixture, false, (line, token) => {
+    await getTokens(registry, path, fixture, false, false, (line, token) => {
         const source = line.substring(token.startIndex, token.endIndex);
         if (source.trim() === "") {
             return true;

--- a/test/source/get_tokens.js
+++ b/test/source/get_tokens.js
@@ -5,6 +5,8 @@ const vsctm = require("vscode-textmate-experimental");
 const paths = require("./paths");
 const fs = require("fs");
 
+const node_process = require("process");
+
 // retrive all the filetypes from the syntax
 let extensionsFor = {};
 for (let eachSyntaxPath of paths["eachJsonSyntax"]) {
@@ -27,7 +29,7 @@ let languageExtensionFor = fixturePath => {
             extensionsFor[eachLangExtension].includes(fixtureExtension)
         ) {
             matchingLanguageExtension = eachLangExtension;
-            break;
+            // break;
         }
     }
     return matchingLanguageExtension;
@@ -45,6 +47,7 @@ module.exports = async function(
     fixturePath,
     fixture,
     showFailureOnly,
+    showLineNumbers,
     process
 ) {
     let displayedAtLeastOnce = false;
@@ -56,6 +59,11 @@ module.exports = async function(
         let ruleStack = null;
         let lineNumber = 1;
         for (const line of fixture) {
+            if (showLineNumbers) {
+                node_process.stdout.write(
+                    "Processing line: " + lineNumber + "\r"
+                );
+            }
             let r = grammar.tokenizeLine(line, ruleStack);
             ruleStack = r.ruleStack;
             let displayLine = false;

--- a/test/source/test_runner.js
+++ b/test/source/test_runner.js
@@ -7,9 +7,20 @@ const SpecChecker = require("./spec_checker").SpecChecker;
  * @param {string[]} fixture
  * @param {object} spec
  */
-module.exports = async function(registry, path, fixture, spec, showFailureOnly) {
+module.exports = async function(
+    registry,
+    path,
+    fixture,
+    spec,
+    showFailureOnly
+) {
     const checker = new SpecChecker(spec, showFailureOnly);
-    return getTokens(registry, path, fixture, showFailureOnly, (line, token) =>
-        checker.checkToken(line, token)
+    return getTokens(
+        registry,
+        path,
+        fixture,
+        showFailureOnly,
+        false,
+        (line, token) => checker.checkToken(line, token)
     );
 };


### PR DESCRIPTION
When generating a report, this PR displays an overwritable line number that is currently being processed. This is useful when debugging performance issues of large files, as you can tell when the grammar is stuck or just processing a large number of lines.