### PR TITLE
general improvements to perf tool

### DIFF
--- a/test/source/commands/report.js
+++ b/test/source/commands/report.js
@@ -2,6 +2,7 @@ const fs = require("fs");
 const glob = require("glob");
 const path = require("path");
 const _ = require("lodash");
+const { performance } = require("perf_hooks");
 
 const getTokens = require("../get_tokens");
 const { getOniguruma } = require("../report/oniguruma_decorator");
@@ -41,7 +42,10 @@ async function runReport(yargs) {
             .readFileSync(eachFile)
             .toString()
             .split("\n");
+        let startTime = performance.now();
         await getTokens(registry, eachFile, fixture, false, true, () => true);
+        let endTime = performance.now();
+        console.log("total time: %dms", endTime - startTime);
     }
     console.log();
     recorder.reportAllRecorders();

--- a/test/source/report/onig_scanner.js
+++ b/test/source/report/onig_scanner.js
@@ -4,6 +4,7 @@
 const vsctm = require("vscode-textmate");
 const oniguruma = require("oniguruma");
 const { performance } = require("perf_hooks");
+const _ = require("lodash");
 
 module.exports = class OnigScanner {
     /**
@@ -80,7 +81,13 @@ module.exports = class OnigScanner {
                 this.patterns.length === 1
             );
         }
-        // use a genuine OnigScanner return as the result format is slightly different
-        return this.onigScanner.findNextMatchSync(string, startPosition);
+        if (chosenResult.match === null) {
+            return null;
+        }
+        return {
+            index: _.findIndex(results, "chosen"),
+            captureIndices: chosenResult.match,
+            scanner: this
+        };
     }
 };

--- a/test/source/report/recorder.js
+++ b/test/source/report/recorder.js
@@ -33,6 +33,13 @@ class recorder {
     record(source, time, chosen, failure, onlyPattern) {
         this.empty = false;
         const index = failure ? 0 : chosen ? 2 : 1;
+        if (this.coverage[source] === undefined) {
+            this.coverage[source] = {
+                source,
+                count: [0, 0, 0],
+                sumTime: [0, 0, 0]
+            };
+        }
         this.coverage[source].count[index] += 1;
         this.coverage[source].sumTime[index] += time;
         if (onlyPattern && chosen) {


### PR DESCRIPTION
Changes:
 - works with embedded macro grammar
 - report total time for a file
 - eliminate unneeded onigScanner

I was thinking in a later PR of making part of `npm test` a check that no more than 40% of the time (maybe per file) is spent matching regular expressions.