### PR TITLE
Update backslash_escapes.rb

### DIFF
--- a/source/shared_patterns/backslash_escapes.rb
+++ b/source/shared_patterns/backslash_escapes.rb
@@ -1,6 +1,6 @@
 def backslash_escapes
     {
-        match: "(?x)\\\\ (\n\\\\\t\t\t |\n[abefnprtv'\"?]   |\n[0-3]\\d{,2}\t |\n[4-7]\\d?\t\t|\nx[a-fA-F0-9]{,2} |\nu[a-fA-F0-9]{,4} |\nU[a-fA-F0-9]{,8} )",
+        match: "(?x)\\\\ (\n\\\\\t\t\t |\n[abefnprtv'\"?]   |\n[0-3][0-7]{,2}\t |\n[4-7]\\d?\t\t|\nx[a-fA-F0-9]{,2} |\nu[a-fA-F0-9]{,4} |\nU[a-fA-F0-9]{,8} )",
         name: "constant.character.escape"
     }
 end


### PR DESCRIPTION
fix `"\018"` highlighting issue, which should be identified as two characters.
the issue occurs in c/oc/ocpp but not in cpp.