### PR TITLE
Support Objective-C nullability, __block, and more property attributes

### DIFF
--- a/source/languages/objc/examples/examples.m
+++ b/source/languages/objc/examples/examples.m
@@ -1,3 +1,4 @@
+@implementation CameraManager
 - (nonnull NSArray<NSString *> *)getCameras {
     // get list of regular cameras
     AVCaptureDeviceDiscoverySession *session = [AVCaptureDeviceDiscoverySession 
@@ -19,3 +20,4 @@
 
     return lst;
 }
+@end

--- a/source/languages/objc/examples/examples.spec.yaml
+++ b/source/languages/objc/examples/examples.spec.yaml
@@ -1,36 +1,54 @@
-- source: '-'
+- source: '@'
+  scopesBegin:
+    - meta.implementation
+    - storage.type
   scopes:
-    - keyword.operator
+    - punctuation.definition.storage.type
+- source: implementation
+  scopesEnd:
+    - storage.type
+- source: CameraManager
+  scopes:
+    - entity.name.type
+- source: '- '
+  scopesBegin:
+    - meta.scope.implementation
+    - meta.function-with-body
+    - meta.function
 - source: (
   scopesBegin:
-    - meta.parens
+    - meta.return-type
   scopes:
-    - punctuation.section.parens.begin.bracket.round
-- source: 'nonnull '
+    - punctuation.definition.type.begin
+- source: nonnull
+  scopes:
+    - storage.modifier.protocol
 - source: NSArray
   scopes:
     - support.class.cocoa
 - source: <
+  scopesBegin:
+    - meta.protocol-list
   scopes:
-    - keyword.operator.comparison
-- source: NSString
-  scopes:
-    - support.class.cocoa
-- source: '*'
-  scopes:
-    - keyword.operator
+    - punctuation.section.scope.begin
+- source: NSString *
 - source: '>'
   scopes:
-    - keyword.operator.comparison
+    - punctuation.section.scope.end
+  scopesEnd:
+    - meta.protocol-list
 - source: '*'
   scopes:
     - keyword.operator
 - source: )
   scopes:
-    - punctuation.section.parens.end.bracket.round
+    - punctuation.definition.type.end
+- source: getCameras
+  scopes:
+    - entity.name.function
   scopesEnd:
-    - meta.parens
-- source: 'getCameras '
+    - meta.function
+    - meta.return-type
 - source: '{'
   scopesBegin:
     - meta.block
@@ -456,3 +474,13 @@
 - source: '}'
   scopes:
     - punctuation.section.block.end.bracket.curly
+  scopesEnd:
+    - meta.scope.implementation
+    - meta.function-with-body
+    - meta.block
+- source: '@'
+  scopesBegin:
+    - storage.type
+  scopes:
+    - punctuation.definition.storage.type
+- source: end

--- a/source/languages/objc/original.tmLanguage.json
+++ b/source/languages/objc/original.tmLanguage.json
@@ -3539,7 +3539,7 @@
           "name": "meta.property-with-attributes.objc",
           "patterns": [
             {
-              "match": "\\b(getter|setter|readonly|readwrite|assign|retain|copy|nonatomic|atomic|strong|weak|nonnull|nullable|null_resettable|class|direct)\\b",
+              "match": "\\b(getter|setter|readonly|readwrite|assign|retain|copy|nonatomic|atomic|strong|weak|nonnull|nullable|null_resettable|null_unspecified|class|direct)\\b",
               "name": "keyword.other.property.attribute.objc"
             }
           ]
@@ -3589,7 +3589,7 @@
       ]
     },
     "protocol_type_qualifier": {
-      "match": "\\b(in|out|inout|oneway|bycopy|byref|nonnull|nullable|_Nonnull|_Nullable)\\b",
+      "match": "\\b(in|out|inout|oneway|bycopy|byref|nonnull|nullable|_Nonnull|_Nullable|_Null_unspecified)\\b",
       "name": "storage.modifier.protocol.objc"
     },
     "special_variables": {

--- a/source/languages/objc/original.tmLanguage.json
+++ b/source/languages/objc/original.tmLanguage.json
@@ -321,7 +321,7 @@
           "name": "keyword.other.typedef.objc"
         },
         {
-          "match": "\\b(const|extern|register|restrict|static|volatile|inline)\\b",
+          "match": "\\b(const|extern|register|restrict|static|volatile|inline|__block)\\b",
           "name": "storage.modifier.objc"
         },
         {
@@ -3539,7 +3539,7 @@
           "name": "meta.property-with-attributes.objc",
           "patterns": [
             {
-              "match": "\\b(getter|setter|readonly|readwrite|assign|retain|copy|nonatomic|strong|weak)\\b",
+              "match": "\\b(getter|setter|readonly|readwrite|assign|retain|copy|nonatomic|atomic|strong|weak|nonnull|nullable|null_resettable|class|direct)\\b",
               "name": "keyword.other.property.attribute.objc"
             }
           ]
@@ -3589,7 +3589,7 @@
       ]
     },
     "protocol_type_qualifier": {
-      "match": "\\b(in|out|inout|oneway|bycopy|byref)\\b",
+      "match": "\\b(in|out|inout|oneway|bycopy|byref|nonnull|nullable|_Nonnull|_Nullable)\\b",
       "name": "storage.modifier.protocol.objc"
     },
     "special_variables": {

--- a/source/languages/objcpp/examples/misc.spec.yaml
+++ b/source/languages/objcpp/examples/misc.spec.yaml
@@ -172,7 +172,9 @@
     - meta.block
   scopes:
     - punctuation.section.block.begin.bracket.curly
-- source: '    __block '
+- source: __block
+  scopes:
+    - storage.modifier.objc
 - source: bool
   scopes:
     - storage.type.built-in.primitive

--- a/source/languages/objcpp/original.tmLanguage.json
+++ b/source/languages/objcpp/original.tmLanguage.json
@@ -325,7 +325,7 @@
           "name": "keyword.other.typedef.objcpp"
         },
         {
-          "match": "\\b(const|extern|register|restrict|static|volatile|inline)\\b",
+          "match": "\\b(const|extern|register|restrict|static|volatile|inline|__block)\\b",
           "name": "storage.modifier.objcpp"
         },
         {
@@ -7032,7 +7032,7 @@
           "name": "meta.property-with-attributes.objcpp",
           "patterns": [
             {
-              "match": "\\b(getter|setter|readonly|readwrite|assign|retain|copy|nonatomic|strong|weak)\\b",
+              "match": "\\b(getter|setter|readonly|readwrite|assign|retain|copy|nonatomic|atomic|strong|weak|nonnull|nullable|null_resettable|class|direct)\\b",
               "name": "keyword.other.property.attribute.objcpp"
             }
           ]
@@ -7082,7 +7082,7 @@
       ]
     },
     "protocol_type_qualifier": {
-      "match": "\\b(in|out|inout|oneway|bycopy|byref)\\b",
+      "match": "\\b(in|out|inout|oneway|bycopy|byref|nonnull|nullable|_Nonnull|_Nullable)\\b",
       "name": "storage.modifier.protocol.objcpp"
     },
     "special_variables": {

--- a/source/languages/objcpp/original.tmLanguage.json
+++ b/source/languages/objcpp/original.tmLanguage.json
@@ -7032,7 +7032,7 @@
           "name": "meta.property-with-attributes.objcpp",
           "patterns": [
             {
-              "match": "\\b(getter|setter|readonly|readwrite|assign|retain|copy|nonatomic|atomic|strong|weak|nonnull|nullable|null_resettable|class|direct)\\b",
+              "match": "\\b(getter|setter|readonly|readwrite|assign|retain|copy|nonatomic|atomic|strong|weak|nonnull|nullable|null_resettable|null_unspecified|class|direct)\\b",
               "name": "keyword.other.property.attribute.objcpp"
             }
           ]
@@ -7082,7 +7082,7 @@
       ]
     },
     "protocol_type_qualifier": {
-      "match": "\\b(in|out|inout|oneway|bycopy|byref|nonnull|nullable|_Nonnull|_Nullable)\\b",
+      "match": "\\b(in|out|inout|oneway|bycopy|byref|nonnull|nullable|_Nonnull|_Nullable|_Null_unspecified)\\b",
       "name": "storage.modifier.protocol.objcpp"
     },
     "special_variables": {

--- a/syntaxes/objc.tmLanguage.json
+++ b/syntaxes/objc.tmLanguage.json
@@ -502,7 +502,7 @@
           "name": "keyword.other.typedef.objc"
         },
         {
-          "match": "\\b(const|extern|register|restrict|static|volatile|inline)\\b",
+          "match": "\\b(const|extern|register|restrict|static|volatile|inline|__block)\\b",
           "name": "storage.modifier.objc"
         },
         {
@@ -3512,7 +3512,7 @@
           "name": "meta.property-with-attributes.objc",
           "patterns": [
             {
-              "match": "\\b(getter|setter|readonly|readwrite|assign|retain|copy|nonatomic|strong|weak)\\b",
+              "match": "\\b(getter|setter|readonly|readwrite|assign|retain|copy|nonatomic|atomic|strong|weak|nonnull|nullable|null_resettable|class|direct)\\b",
               "name": "keyword.other.property.attribute.objc"
             }
           ]
@@ -3562,7 +3562,7 @@
       ]
     },
     "protocol_type_qualifier": {
-      "match": "\\b(in|out|inout|oneway|bycopy|byref)\\b",
+      "match": "\\b(in|out|inout|oneway|bycopy|byref|nonnull|nullable|_Nonnull|_Nullable)\\b",
       "name": "storage.modifier.protocol.objc"
     },
     "special_variables": {

--- a/syntaxes/objc.tmLanguage.json
+++ b/syntaxes/objc.tmLanguage.json
@@ -3512,7 +3512,7 @@
           "name": "meta.property-with-attributes.objc",
           "patterns": [
             {
-              "match": "\\b(getter|setter|readonly|readwrite|assign|retain|copy|nonatomic|atomic|strong|weak|nonnull|nullable|null_resettable|class|direct)\\b",
+              "match": "\\b(getter|setter|readonly|readwrite|assign|retain|copy|nonatomic|atomic|strong|weak|nonnull|nullable|null_resettable|null_unspecified|class|direct)\\b",
               "name": "keyword.other.property.attribute.objc"
             }
           ]
@@ -3562,7 +3562,7 @@
       ]
     },
     "protocol_type_qualifier": {
-      "match": "\\b(in|out|inout|oneway|bycopy|byref|nonnull|nullable|_Nonnull|_Nullable)\\b",
+      "match": "\\b(in|out|inout|oneway|bycopy|byref|nonnull|nullable|_Nonnull|_Nullable|_Null_unspecified)\\b",
       "name": "storage.modifier.protocol.objc"
     },
     "special_variables": {

--- a/syntaxes/objcpp.tmLanguage.json
+++ b/syntaxes/objcpp.tmLanguage.json
@@ -7005,7 +7005,7 @@
           "name": "meta.property-with-attributes.objcpp",
           "patterns": [
             {
-              "match": "\\b(getter|setter|readonly|readwrite|assign|retain|copy|nonatomic|atomic|strong|weak|nonnull|nullable|null_resettable|class|direct)\\b",
+              "match": "\\b(getter|setter|readonly|readwrite|assign|retain|copy|nonatomic|atomic|strong|weak|nonnull|nullable|null_resettable|null_unspecified|class|direct)\\b",
               "name": "keyword.other.property.attribute.objcpp"
             }
           ]
@@ -7055,7 +7055,7 @@
       ]
     },
     "protocol_type_qualifier": {
-      "match": "\\b(in|out|inout|oneway|bycopy|byref|nonnull|nullable|_Nonnull|_Nullable)\\b",
+      "match": "\\b(in|out|inout|oneway|bycopy|byref|nonnull|nullable|_Nonnull|_Nullable|_Null_unspecified)\\b",
       "name": "storage.modifier.protocol.objcpp"
     },
     "special_variables": {

--- a/syntaxes/objcpp.tmLanguage.json
+++ b/syntaxes/objcpp.tmLanguage.json
@@ -506,7 +506,7 @@
           "name": "keyword.other.typedef.objcpp"
         },
         {
-          "match": "\\b(const|extern|register|restrict|static|volatile|inline)\\b",
+          "match": "\\b(const|extern|register|restrict|static|volatile|inline|__block)\\b",
           "name": "storage.modifier.objcpp"
         },
         {
@@ -7005,7 +7005,7 @@
           "name": "meta.property-with-attributes.objcpp",
           "patterns": [
             {
-              "match": "\\b(getter|setter|readonly|readwrite|assign|retain|copy|nonatomic|strong|weak)\\b",
+              "match": "\\b(getter|setter|readonly|readwrite|assign|retain|copy|nonatomic|atomic|strong|weak|nonnull|nullable|null_resettable|class|direct)\\b",
               "name": "keyword.other.property.attribute.objcpp"
             }
           ]
@@ -7055,7 +7055,7 @@
       ]
     },
     "protocol_type_qualifier": {
-      "match": "\\b(in|out|inout|oneway|bycopy|byref)\\b",
+      "match": "\\b(in|out|inout|oneway|bycopy|byref|nonnull|nullable|_Nonnull|_Nullable)\\b",
       "name": "storage.modifier.protocol.objcpp"
     },
     "special_variables": {


### PR DESCRIPTION
Adds support for the following:
- `__block` storage modifier
- Property attributes: `nonnull`, `nullable`, `null_resettable`, `atomic`, `class`, and `direct`
- Type modifiers: `nonnull`, `nullable`, `_Nonnull`, and `_Nullable`

See the related https://github.com/jeff-hykin/cpp-textmate-grammar/issues/538, although this commit/PR does not add support for the `self`/`super`/`_cmd`.