### PR TITLE
Improve Objective-C and Objective-C++ highlighting

### DIFF
--- a/source/languages/objc/examples/examples.spec.yaml
+++ b/source/languages/objc/examples/examples.spec.yaml
@@ -72,29 +72,29 @@
     - keyword.operator.assignment
 - source: '['
   scopesBegin:
-    - meta.bracket.square.access
+    - meta.bracketed
   scopes:
-    - punctuation.definition.begin.bracket.square
+    - punctuation.section.scope.begin
 - source: 'AVCaptureDeviceDiscoverySession '
 - source: '        discoverySessionWithDeviceTypes:@'
 - source: '['
   scopesBegin:
-    - meta.bracket.square.access
+    - meta.bracketed
   scopes:
-    - punctuation.definition.begin.bracket.square
+    - punctuation.section.scope.begin
 - source: AVCaptureDeviceTypeBuiltInWideAngleCamera
 - source: ']'
   scopes:
-    - punctuation.definition.end.bracket.square
+    - punctuation.section.scope.end
   scopesEnd:
-    - meta.bracket.square.access
+    - meta.bracketed
 - source: '        mediaType:AVMediaTypeVideo '
 - source: '        position:AVCaptureDevicePositionUnspecified'
 - source: ']'
   scopes:
-    - punctuation.definition.end.bracket.square
+    - punctuation.section.scope.end
   scopesEnd:
-    - meta.bracket.square.access
+    - meta.bracketed
 - source: ;
   scopes:
     - punctuation.terminator.statement
@@ -130,29 +130,35 @@
     - keyword.operator.assignment
 - source: '['
   scopesBegin:
-    - meta.bracket.square.access
+    - meta.bracketed
   scopes:
-    - punctuation.definition.begin.bracket.square
+    - punctuation.section.scope.begin
 - source: '['
   scopesBegin:
-    - meta.bracket.square.access
+    - meta.bracketed
   scopes:
-    - punctuation.definition.begin.bracket.square
+    - punctuation.section.scope.begin
 - source: NSMutableArray
   scopes:
     - support.class.cocoa
-- source: ' alloc'
+- source: alloc
+  scopes:
+    - meta.function-call
+    - support.function.any-method
 - source: ']'
   scopes:
-    - punctuation.definition.end.bracket.square
+    - punctuation.section.scope.end
   scopesEnd:
-    - meta.bracket.square.access
-- source: ' init'
+    - meta.bracketed
+- source: init
+  scopes:
+    - meta.function-call
+    - support.function.any-method
 - source: ']'
   scopes:
-    - punctuation.definition.end.bracket.square
+    - punctuation.section.scope.end
   scopesEnd:
-    - meta.bracket.square.access
+    - meta.bracketed
 - source: ;
   scopes:
     - punctuation.terminator.statement
@@ -168,7 +174,10 @@
 - source: '*'
   scopes:
     - keyword.operator
-- source: 'device in '
+- source: 'device '
+- source: in
+  scopes:
+    - keyword.other.in
 - source: session
   scopes:
     - variable.other.object.access
@@ -216,10 +225,19 @@
     - keyword.operator.assignment
 - source: '['
   scopesBegin:
-    - meta.bracket.square.access
+    - meta.bracketed
   scopes:
-    - punctuation.definition.begin.bracket.square
-- source: 's stringByAppendingFormat:'
+    - punctuation.section.scope.begin
+- source: 's '
+- source: stringByAppendingFormat
+  scopesBegin:
+    - meta.function-call
+    - support.function.any-method
+- source: ':'
+  scopes:
+    - punctuation.separator.arguments
+  scopesEnd:
+    - support.function.any-method
 - source: '@"'
   scopesBegin:
     - string.quoted.double
@@ -245,20 +263,14 @@
 - source: ','
   scopes:
     - punctuation.separator.delimiter
-- source: device
-  scopes:
-    - variable.other.object.access
-- source: .
-  scopes:
-    - punctuation.separator.dot-access
-- source: uniqueID
-  scopes:
-    - variable.other.member
+- source: ' device.uniqueID'
+  scopesEnd:
+    - meta.function-call
 - source: ']'
   scopes:
-    - punctuation.definition.end.bracket.square
+    - punctuation.section.scope.end
   scopesEnd:
-    - meta.bracket.square.access
+    - meta.bracketed
 - source: ;
   scopes:
     - punctuation.terminator.statement
@@ -268,10 +280,19 @@
     - keyword.operator.assignment
 - source: '['
   scopesBegin:
-    - meta.bracket.square.access
+    - meta.bracketed
   scopes:
-    - punctuation.definition.begin.bracket.square
-- source: 's stringByAppendingFormat:'
+    - punctuation.section.scope.begin
+- source: 's '
+- source: stringByAppendingFormat
+  scopesBegin:
+    - meta.function-call
+    - support.function.any-method
+- source: ':'
+  scopes:
+    - punctuation.separator.arguments
+  scopesEnd:
+    - support.function.any-method
 - source: '@"'
   scopesBegin:
     - string.quoted.double
@@ -297,15 +318,7 @@
 - source: ','
   scopes:
     - punctuation.separator.delimiter
-- source: device
-  scopes:
-    - variable.other.object.access
-- source: .
-  scopes:
-    - punctuation.separator.dot-access
-- source: position
-  scopes:
-    - variable.other.member
+- source: ' device.position '
 - source: ==
   scopes:
     - keyword.operator.comparison
@@ -337,12 +350,13 @@
   scopes:
     - punctuation.definition.string.end
   scopesEnd:
+    - meta.function-call
     - string.quoted.double
 - source: ']'
   scopes:
-    - punctuation.definition.end.bracket.square
+    - punctuation.section.scope.end
   scopesEnd:
-    - meta.bracket.square.access
+    - meta.bracketed
 - source: ;
   scopes:
     - punctuation.terminator.statement
@@ -352,10 +366,19 @@
     - keyword.operator.assignment
 - source: '['
   scopesBegin:
-    - meta.bracket.square.access
+    - meta.bracketed
   scopes:
-    - punctuation.definition.begin.bracket.square
-- source: 's stringByAppendingFormat:'
+    - punctuation.section.scope.begin
+- source: 's '
+- source: stringByAppendingFormat
+  scopesBegin:
+    - meta.function-call
+    - support.function.any-method
+- source: ':'
+  scopes:
+    - punctuation.separator.arguments
+  scopesEnd:
+    - support.function.any-method
 - source: '@"'
   scopesBegin:
     - string.quoted.double
@@ -373,12 +396,13 @@
   scopes:
     - punctuation.definition.string.end
   scopesEnd:
+    - meta.function-call
     - string.quoted.double
 - source: ']'
   scopes:
-    - punctuation.definition.end.bracket.square
+    - punctuation.section.scope.end
   scopesEnd:
-    - meta.bracket.square.access
+    - meta.bracketed
 - source: ;
   scopes:
     - punctuation.terminator.statement
@@ -388,10 +412,19 @@
     - keyword.operator.assignment
 - source: '['
   scopesBegin:
-    - meta.bracket.square.access
+    - meta.bracketed
   scopes:
-    - punctuation.definition.begin.bracket.square
-- source: 's stringByAppendingFormat:'
+    - punctuation.section.scope.begin
+- source: 's '
+- source: stringByAppendingFormat
+  scopesBegin:
+    - meta.function-call
+    - support.function.any-method
+- source: ':'
+  scopes:
+    - punctuation.separator.arguments
+  scopesEnd:
+    - support.function.any-method
 - source: '@"'
   scopesBegin:
     - string.quoted.double
@@ -409,12 +442,13 @@
   scopes:
     - punctuation.definition.string.end
   scopesEnd:
+    - meta.function-call
     - string.quoted.double
 - source: ']'
   scopes:
-    - punctuation.definition.end.bracket.square
+    - punctuation.section.scope.end
   scopesEnd:
-    - meta.bracket.square.access
+    - meta.bracketed
 - source: ;
   scopes:
     - punctuation.terminator.statement
@@ -424,10 +458,19 @@
     - keyword.operator.assignment
 - source: '['
   scopesBegin:
-    - meta.bracket.square.access
+    - meta.bracketed
   scopes:
-    - punctuation.definition.begin.bracket.square
-- source: 's stringByAppendingString:'
+    - punctuation.section.scope.begin
+- source: 's '
+- source: stringByAppendingString
+  scopesBegin:
+    - meta.function-call
+    - support.function.any-method
+- source: ':'
+  scopes:
+    - punctuation.separator.arguments
+  scopesEnd:
+    - support.function.any-method
 - source: '@"'
   scopesBegin:
     - string.quoted.double
@@ -438,26 +481,39 @@
   scopes:
     - punctuation.definition.string.end
   scopesEnd:
+    - meta.function-call
     - string.quoted.double
 - source: ']'
   scopes:
-    - punctuation.definition.end.bracket.square
+    - punctuation.section.scope.end
   scopesEnd:
-    - meta.bracket.square.access
+    - meta.bracketed
 - source: ;
   scopes:
     - punctuation.terminator.statement
 - source: '['
   scopesBegin:
-    - meta.bracket.square.access
+    - meta.bracketed
   scopes:
-    - punctuation.definition.begin.bracket.square
-- source: 'lst addObject:s'
+    - punctuation.section.scope.begin
+- source: 'lst '
+- source: addObject
+  scopesBegin:
+    - meta.function-call
+    - support.function.any-method
+- source: ':'
+  scopes:
+    - punctuation.separator.arguments
+  scopesEnd:
+    - support.function.any-method
+- source: s
+  scopesEnd:
+    - meta.function-call
 - source: ']'
   scopes:
-    - punctuation.definition.end.bracket.square
+    - punctuation.section.scope.end
   scopesEnd:
-    - meta.bracket.square.access
+    - meta.bracketed
 - source: ;
   scopes:
     - punctuation.terminator.statement

--- a/source/languages/objc/examples/misc_002.spec.yaml
+++ b/source/languages/objc/examples/misc_002.spec.yaml
@@ -260,21 +260,37 @@
     - meta.block
   scopes:
     - punctuation.section.block.begin.bracket.curly
-- source: '    self '
+- source: self
+  scopes:
+    - variable.language
 - source: =
   scopes:
     - keyword.operator.assignment
 - source: '['
   scopesBegin:
-    - meta.bracket.square.access
+    - meta.bracketed
   scopes:
-    - punctuation.definition.begin.bracket.square
-- source: 'super initWithFrame:frame'
+    - punctuation.section.scope.begin
+- source: super
+  scopes:
+    - variable.language
+- source: initWithFrame
+  scopesBegin:
+    - meta.function-call
+    - support.function.any-method
+- source: ':'
+  scopes:
+    - punctuation.separator.arguments
+  scopesEnd:
+    - support.function.any-method
+- source: frame
+  scopesEnd:
+    - meta.function-call
 - source: ']'
   scopes:
-    - punctuation.definition.end.bracket.square
+    - punctuation.section.scope.end
   scopesEnd:
-    - meta.bracket.square.access
+    - meta.bracketed
 - source: ;
   scopes:
     - punctuation.terminator.statement
@@ -286,7 +302,9 @@
     - meta.parens.block
   scopes:
     - punctuation.section.parens.begin.bracket.round
-- source: 'self '
+- source: self
+  scopes:
+    - variable.language
 - source: '!='
   scopes:
     - keyword.operator.comparison
@@ -303,19 +321,40 @@
     - punctuation.section.block.begin.bracket.curly
 - source: '['
   scopesBegin:
-    - meta.bracket.square.access
+    - meta.bracketed
   scopes:
-    - punctuation.definition.begin.bracket.square
-- source: 'self setupWithEffect:BBCyclingLabelTransitionEffectDefault'
-- source: '                  andDuration:'
+    - punctuation.section.scope.begin
+- source: self
+  scopes:
+    - variable.language
+- source: setupWithEffect
+  scopesBegin:
+    - meta.function-call
+    - support.function.any-method
+- source: ':'
+  scopes:
+    - punctuation.separator.arguments
+  scopesEnd:
+    - support.function.any-method
+- source: BBCyclingLabelTransitionEffectDefault
+- source: andDuration
+  scopesBegin:
+    - support.function.any-method.name-of-parameter
+- source: ':'
+  scopes:
+    - punctuation.separator.arguments
+  scopesEnd:
+    - support.function.any-method.name-of-parameter
 - source: kBBCyclingLabelDefaultTransitionDuration
   scopes:
     - constant.other.variable.mac-classic
+  scopesEnd:
+    - meta.function-call
 - source: ']'
   scopes:
-    - punctuation.definition.end.bracket.square
+    - punctuation.section.scope.end
   scopesEnd:
-    - meta.bracket.square.access
+    - meta.bracketed
 - source: ;
   scopes:
     - punctuation.terminator.statement
@@ -325,7 +364,9 @@
 - source: return
   scopes:
     - keyword.control
-- source: ' self'
+- source: self
+  scopes:
+    - variable.language
 - source: ;
   scopes:
     - punctuation.terminator.statement
@@ -382,21 +423,37 @@
     - meta.block
   scopes:
     - punctuation.section.block.begin.bracket.curly
-- source: '    self '
+- source: self
+  scopes:
+    - variable.language
 - source: =
   scopes:
     - keyword.operator.assignment
 - source: '['
   scopesBegin:
-    - meta.bracket.square.access
+    - meta.bracketed
   scopes:
-    - punctuation.definition.begin.bracket.square
-- source: 'super initWithCoder:coder'
+    - punctuation.section.scope.begin
+- source: super
+  scopes:
+    - variable.language
+- source: initWithCoder
+  scopesBegin:
+    - meta.function-call
+    - support.function.any-method
+- source: ':'
+  scopes:
+    - punctuation.separator.arguments
+  scopesEnd:
+    - support.function.any-method
+- source: coder
+  scopesEnd:
+    - meta.function-call
 - source: ']'
   scopes:
-    - punctuation.definition.end.bracket.square
+    - punctuation.section.scope.end
   scopesEnd:
-    - meta.bracket.square.access
+    - meta.bracketed
 - source: ;
   scopes:
     - punctuation.terminator.statement
@@ -408,7 +465,9 @@
     - meta.parens.block
   scopes:
     - punctuation.section.parens.begin.bracket.round
-- source: 'self '
+- source: self
+  scopes:
+    - variable.language
 - source: '!='
   scopes:
     - keyword.operator.comparison
@@ -425,19 +484,40 @@
     - punctuation.section.block.begin.bracket.curly
 - source: '['
   scopesBegin:
-    - meta.bracket.square.access
+    - meta.bracketed
   scopes:
-    - punctuation.definition.begin.bracket.square
-- source: 'self setupWithEffect:BBCyclingLabelTransitionEffectDefault'
-- source: '                  andDuration:'
+    - punctuation.section.scope.begin
+- source: self
+  scopes:
+    - variable.language
+- source: setupWithEffect
+  scopesBegin:
+    - meta.function-call
+    - support.function.any-method
+- source: ':'
+  scopes:
+    - punctuation.separator.arguments
+  scopesEnd:
+    - support.function.any-method
+- source: BBCyclingLabelTransitionEffectDefault
+- source: andDuration
+  scopesBegin:
+    - support.function.any-method.name-of-parameter
+- source: ':'
+  scopes:
+    - punctuation.separator.arguments
+  scopesEnd:
+    - support.function.any-method.name-of-parameter
 - source: kBBCyclingLabelDefaultTransitionDuration
   scopes:
     - constant.other.variable.mac-classic
+  scopesEnd:
+    - meta.function-call
 - source: ']'
   scopes:
-    - punctuation.definition.end.bracket.square
+    - punctuation.section.scope.end
   scopesEnd:
-    - meta.bracket.square.access
+    - meta.bracketed
 - source: ;
   scopes:
     - punctuation.terminator.statement
@@ -447,7 +527,9 @@
 - source: return
   scopes:
     - keyword.control
-- source: ' self'
+- source: self
+  scopes:
+    - variable.language
 - source: ;
   scopes:
     - punctuation.terminator.statement
@@ -522,21 +604,37 @@
     - meta.block
   scopes:
     - punctuation.section.block.begin.bracket.curly
-- source: '    self '
+- source: self
+  scopes:
+    - variable.language
 - source: =
   scopes:
     - keyword.operator.assignment
 - source: '['
   scopesBegin:
-    - meta.bracket.square.access
+    - meta.bracketed
   scopes:
-    - punctuation.definition.begin.bracket.square
-- source: 'super initWithFrame:frame'
+    - punctuation.section.scope.begin
+- source: super
+  scopes:
+    - variable.language
+- source: initWithFrame
+  scopesBegin:
+    - meta.function-call
+    - support.function.any-method
+- source: ':'
+  scopes:
+    - punctuation.separator.arguments
+  scopesEnd:
+    - support.function.any-method
+- source: frame
+  scopesEnd:
+    - meta.function-call
 - source: ']'
   scopes:
-    - punctuation.definition.end.bracket.square
+    - punctuation.section.scope.end
   scopesEnd:
-    - meta.bracket.square.access
+    - meta.bracketed
 - source: ;
   scopes:
     - punctuation.terminator.statement
@@ -548,7 +646,9 @@
     - meta.parens.block
   scopes:
     - punctuation.section.parens.begin.bracket.round
-- source: 'self '
+- source: self
+  scopes:
+    - variable.language
 - source: '!='
   scopes:
     - keyword.operator.comparison
@@ -565,19 +665,40 @@
     - punctuation.section.block.begin.bracket.curly
 - source: '['
   scopesBegin:
-    - meta.bracket.square.access
+    - meta.bracketed
   scopes:
-    - punctuation.definition.begin.bracket.square
-- source: 'self setupWithEffect:transitionEffect'
-- source: '                  andDuration:'
+    - punctuation.section.scope.begin
+- source: self
+  scopes:
+    - variable.language
+- source: setupWithEffect
+  scopesBegin:
+    - meta.function-call
+    - support.function.any-method
+- source: ':'
+  scopes:
+    - punctuation.separator.arguments
+  scopesEnd:
+    - support.function.any-method
+- source: transitionEffect
+- source: andDuration
+  scopesBegin:
+    - support.function.any-method.name-of-parameter
+- source: ':'
+  scopes:
+    - punctuation.separator.arguments
+  scopesEnd:
+    - support.function.any-method.name-of-parameter
 - source: kBBCyclingLabelDefaultTransitionDuration
   scopes:
     - constant.other.variable.mac-classic
+  scopesEnd:
+    - meta.function-call
 - source: ']'
   scopes:
-    - punctuation.definition.end.bracket.square
+    - punctuation.section.scope.end
   scopesEnd:
-    - meta.bracket.square.access
+    - meta.bracketed
 - source: ;
   scopes:
     - punctuation.terminator.statement
@@ -587,7 +708,9 @@
 - source: return
   scopes:
     - keyword.control
-- source: ' self'
+- source: self
+  scopes:
+    - variable.language
 - source: ;
   scopes:
     - punctuation.terminator.statement
@@ -667,15 +790,21 @@
     - punctuation.terminator.statement
 - source: '['
   scopesBegin:
-    - meta.bracket.square.access
+    - meta.bracketed
   scopes:
-    - punctuation.definition.begin.bracket.square
-- source: self prepareTransitionBlocks
+    - punctuation.section.scope.begin
+- source: self
+  scopes:
+    - variable.language
+- source: prepareTransitionBlocks
+  scopes:
+    - meta.function-call
+    - support.function.any-method
 - source: ']'
   scopes:
-    - punctuation.definition.end.bracket.square
+    - punctuation.section.scope.end
   scopesEnd:
-    - meta.bracket.square.access
+    - meta.bracketed
 - source: ;
   scopes:
     - punctuation.terminator.statement
@@ -782,18 +911,40 @@
     - punctuation.section.block.begin.bracket.curly
 - source: '['
   scopesBegin:
-    - meta.bracket.square.access
+    - meta.bracketed
   scopes:
-    - punctuation.definition.begin.bracket.square
-- source: 'self setText:text animated:'
+    - punctuation.section.scope.begin
+- source: self
+  scopes:
+    - variable.language
+- source: setText
+  scopesBegin:
+    - meta.function-call
+    - support.function.any-method
+- source: ':'
+  scopes:
+    - punctuation.separator.arguments
+  scopesEnd:
+    - support.function.any-method
+- source: 'text '
+- source: animated
+  scopesBegin:
+    - support.function.any-method.name-of-parameter
+- source: ':'
+  scopes:
+    - punctuation.separator.arguments
+  scopesEnd:
+    - support.function.any-method.name-of-parameter
 - source: 'YES'
   scopes:
     - constant.language
+  scopesEnd:
+    - meta.function-call
 - source: ']'
   scopes:
-    - punctuation.definition.end.bracket.square
+    - punctuation.section.scope.end
   scopesEnd:
-    - meta.bracket.square.access
+    - meta.bracketed
 - source: ;
   scopes:
     - punctuation.terminator.statement
@@ -906,7 +1057,11 @@
 - source: '*'
   scopes:
     - keyword.operator
-- source: ' label in _labels'
+- source: ' label '
+- source: in
+  scopes:
+    - keyword.other.in
+- source: ' _labels'
 - source: )
   scopes:
     - punctuation.section.parens.end.bracket.round
@@ -1042,7 +1197,11 @@
 - source: '*'
   scopes:
     - keyword.operator
-- source: ' label in _labels'
+- source: ' label '
+- source: in
+  scopes:
+    - keyword.other.in
+- source: ' _labels'
 - source: )
   scopes:
     - punctuation.section.parens.end.bracket.round
@@ -1178,7 +1337,11 @@
 - source: '*'
   scopes:
     - keyword.operator
-- source: ' label in _labels'
+- source: ' label '
+- source: in
+  scopes:
+    - keyword.other.in
+- source: ' _labels'
 - source: )
   scopes:
     - punctuation.section.parens.end.bracket.round
@@ -1312,7 +1475,11 @@
 - source: '*'
   scopes:
     - keyword.operator
-- source: ' label in _labels'
+- source: ' label '
+- source: in
+  scopes:
+    - keyword.other.in
+- source: ' _labels'
 - source: )
   scopes:
     - punctuation.section.parens.end.bracket.round
@@ -1446,7 +1613,11 @@
 - source: '*'
   scopes:
     - keyword.operator
-- source: ' label in _labels'
+- source: ' label '
+- source: in
+  scopes:
+    - keyword.other.in
+- source: ' _labels'
 - source: )
   scopes:
     - punctuation.section.parens.end.bracket.round
@@ -1580,7 +1751,11 @@
 - source: '*'
   scopes:
     - keyword.operator
-- source: ' label in _labels'
+- source: ' label '
+- source: in
+  scopes:
+    - keyword.other.in
+- source: ' _labels'
 - source: )
   scopes:
     - punctuation.section.parens.end.bracket.round
@@ -1714,7 +1889,11 @@
 - source: '*'
   scopes:
     - keyword.operator
-- source: ' label in _labels'
+- source: ' label '
+- source: in
+  scopes:
+    - keyword.other.in
+- source: ' _labels'
 - source: )
   scopes:
     - punctuation.section.parens.end.bracket.round
@@ -1848,7 +2027,11 @@
 - source: '*'
   scopes:
     - keyword.operator
-- source: ' label in _labels'
+- source: ' label '
+- source: in
+  scopes:
+    - keyword.other.in
+- source: ' _labels'
 - source: )
   scopes:
     - punctuation.section.parens.end.bracket.round
@@ -1982,7 +2165,11 @@
 - source: '*'
   scopes:
     - keyword.operator
-- source: ' label in _labels'
+- source: ' label '
+- source: in
+  scopes:
+    - keyword.other.in
+- source: ' _labels'
 - source: )
   scopes:
     - punctuation.section.parens.end.bracket.round
@@ -2112,7 +2299,11 @@
 - source: '*'
   scopes:
     - keyword.operator
-- source: ' label in _labels'
+- source: ' label '
+- source: in
+  scopes:
+    - keyword.other.in
+- source: ' _labels'
 - source: )
   scopes:
     - punctuation.section.parens.end.bracket.round
@@ -2242,15 +2433,21 @@
     - keyword.operator.assignment
 - source: '['
   scopesBegin:
-    - meta.bracket.square.access
+    - meta.bracketed
   scopes:
-    - punctuation.definition.begin.bracket.square
-- source: self nextLabelIndex
+    - punctuation.section.scope.begin
+- source: self
+  scopes:
+    - variable.language
+- source: nextLabelIndex
+  scopes:
+    - meta.function-call
+    - support.function.any-method
 - source: ']'
   scopes:
-    - punctuation.definition.end.bracket.square
+    - punctuation.section.scope.end
   scopesEnd:
-    - meta.bracket.square.access
+    - meta.bracketed
 - source: ;
   scopes:
     - punctuation.terminator.statement
@@ -2264,15 +2461,27 @@
     - keyword.operator.assignment
 - source: '['
   scopesBegin:
-    - meta.bracket.square.access
+    - meta.bracketed
   scopes:
-    - punctuation.definition.begin.bracket.square
-- source: '_labels objectAtIndex:nextLabelIndex'
+    - punctuation.section.scope.begin
+- source: '_labels '
+- source: objectAtIndex
+  scopesBegin:
+    - meta.function-call
+    - support.function.any-method
+- source: ':'
+  scopes:
+    - punctuation.separator.arguments
+  scopesEnd:
+    - support.function.any-method
+- source: nextLabelIndex
+  scopesEnd:
+    - meta.function-call
 - source: ']'
   scopes:
-    - punctuation.definition.end.bracket.square
+    - punctuation.section.scope.end
   scopesEnd:
-    - meta.bracket.square.access
+    - meta.bracketed
 - source: ;
   scopes:
     - punctuation.terminator.statement
@@ -2322,15 +2531,29 @@
     - comment.line.double-slash
 - source: '['
   scopesBegin:
-    - meta.bracket.square.access
+    - meta.bracketed
   scopes:
-    - punctuation.definition.begin.bracket.square
-- source: 'self resetLabel:nextLabel'
+    - punctuation.section.scope.begin
+- source: self
+  scopes:
+    - variable.language
+- source: resetLabel
+  scopesBegin:
+    - meta.function-call
+    - support.function.any-method
+- source: ':'
+  scopes:
+    - punctuation.separator.arguments
+  scopesEnd:
+    - support.function.any-method
+- source: nextLabel
+  scopesEnd:
+    - meta.function-call
 - source: ']'
   scopes:
-    - punctuation.definition.end.bracket.square
+    - punctuation.section.scope.end
   scopesEnd:
-    - meta.bracket.square.access
+    - meta.bracketed
 - source: ;
   scopes:
     - punctuation.terminator.statement
@@ -2760,17 +2983,45 @@
     - comment.line.double-slash
 - source: '['
   scopesBegin:
-    - meta.bracket.square.access
+    - meta.bracketed
   scopes:
-    - punctuation.definition.begin.bracket.square
-- source: >-
-    UIView animateWithDuration:_transitionDuration animations:changeBlock
-    completion:completionBlock
+    - punctuation.section.scope.begin
+- source: 'UIView '
+- source: animateWithDuration
+  scopesBegin:
+    - meta.function-call
+    - support.function.any-method
+- source: ':'
+  scopes:
+    - punctuation.separator.arguments
+  scopesEnd:
+    - support.function.any-method
+- source: '_transitionDuration '
+- source: animations
+  scopesBegin:
+    - support.function.any-method.name-of-parameter
+- source: ':'
+  scopes:
+    - punctuation.separator.arguments
+  scopesEnd:
+    - support.function.any-method.name-of-parameter
+- source: 'changeBlock '
+- source: completion
+  scopesBegin:
+    - support.function.any-method.name-of-parameter
+- source: ':'
+  scopes:
+    - punctuation.separator.arguments
+  scopesEnd:
+    - support.function.any-method.name-of-parameter
+- source: completionBlock
+  scopesEnd:
+    - meta.function-call
 - source: ']'
   scopes:
-    - punctuation.definition.end.bracket.square
+    - punctuation.section.scope.end
   scopesEnd:
-    - meta.bracket.square.access
+    - meta.bracketed
 - source: ;
   scopes:
     - punctuation.terminator.statement
@@ -2934,18 +3185,29 @@
     - keyword.operator.assignment
 - source: '['
   scopesBegin:
-    - meta.bracket.square.access
+    - meta.bracketed
   scopes:
-    - punctuation.definition.begin.bracket.square
+    - punctuation.section.scope.begin
 - source: NSMutableArray
   scopes:
     - support.class.cocoa
-- source: ' arrayWithCapacity:size'
+- source: arrayWithCapacity
+  scopesBegin:
+    - meta.function-call
+    - support.function.any-method
+- source: ':'
+  scopes:
+    - punctuation.separator.arguments
+  scopesEnd:
+    - support.function.any-method
+- source: size
+  scopesEnd:
+    - meta.function-call
 - source: ']'
   scopes:
-    - punctuation.definition.end.bracket.square
+    - punctuation.section.scope.end
   scopesEnd:
-    - meta.bracket.square.access
+    - meta.bracketed
 - source: ;
   scopes:
     - punctuation.terminator.statement
@@ -3000,49 +3262,72 @@
     - keyword.operator.assignment
 - source: '['
   scopesBegin:
-    - meta.bracket.square.access
+    - meta.bracketed
   scopes:
-    - punctuation.definition.begin.bracket.square
+    - punctuation.section.scope.begin
 - source: '['
   scopesBegin:
-    - meta.bracket.square.access
+    - meta.bracketed
   scopes:
-    - punctuation.definition.begin.bracket.square
-- source: UILabel alloc
+    - punctuation.section.scope.begin
+- source: 'UILabel '
+- source: alloc
+  scopes:
+    - meta.function-call
+    - support.function.any-method
 - source: ']'
   scopes:
-    - punctuation.definition.end.bracket.square
+    - punctuation.section.scope.end
   scopesEnd:
-    - meta.bracket.square.access
-- source: ' initWithFrame:'
+    - meta.bracketed
+- source: initWithFrame
+  scopesBegin:
+    - meta.function-call
+    - support.function.any-method
+- source: ':'
+  scopes:
+    - punctuation.separator.arguments
+  scopesEnd:
+    - support.function.any-method
 - source: self
   scopes:
-    - variable.other.object.access
-- source: .
-  scopes:
-    - punctuation.separator.dot-access
-- source: bounds
-  scopes:
-    - variable.other.member
+    - variable.language
+- source: .bounds
+  scopesEnd:
+    - meta.function-call
 - source: ']'
   scopes:
-    - punctuation.definition.end.bracket.square
+    - punctuation.section.scope.end
   scopesEnd:
-    - meta.bracket.square.access
+    - meta.bracketed
 - source: ;
   scopes:
     - punctuation.terminator.statement
 - source: '['
   scopesBegin:
-    - meta.bracket.square.access
+    - meta.bracketed
   scopes:
-    - punctuation.definition.begin.bracket.square
-- source: 'self addSubview:label'
+    - punctuation.section.scope.begin
+- source: self
+  scopes:
+    - variable.language
+- source: addSubview
+  scopesBegin:
+    - meta.function-call
+    - support.function.any-method
+- source: ':'
+  scopes:
+    - punctuation.separator.arguments
+  scopesEnd:
+    - support.function.any-method
+- source: label
+  scopesEnd:
+    - meta.function-call
 - source: ']'
   scopes:
-    - punctuation.definition.end.bracket.square
+    - punctuation.section.scope.end
   scopesEnd:
-    - meta.bracket.square.access
+    - meta.bracketed
 - source: ;
   scopes:
     - punctuation.terminator.statement
@@ -3060,15 +3345,19 @@
     - keyword.operator.assignment
 - source: '['
   scopesBegin:
-    - meta.bracket.square.access
+    - meta.bracketed
   scopes:
-    - punctuation.definition.begin.bracket.square
-- source: UIColor clearColor
+    - punctuation.section.scope.begin
+- source: 'UIColor '
+- source: clearColor
+  scopes:
+    - meta.function-call
+    - support.function.any-method
 - source: ']'
   scopes:
-    - punctuation.definition.end.bracket.square
+    - punctuation.section.scope.end
   scopesEnd:
-    - meta.bracket.square.access
+    - meta.bracketed
 - source: ;
   scopes:
     - punctuation.terminator.statement
@@ -3110,15 +3399,27 @@
     - punctuation.terminator.statement
 - source: '['
   scopesBegin:
-    - meta.bracket.square.access
+    - meta.bracketed
   scopes:
-    - punctuation.definition.begin.bracket.square
-- source: 'labels addObject:label'
+    - punctuation.section.scope.begin
+- source: 'labels '
+- source: addObject
+  scopesBegin:
+    - meta.function-call
+    - support.function.any-method
+- source: ':'
+  scopes:
+    - punctuation.separator.arguments
+  scopesEnd:
+    - support.function.any-method
+- source: label
+  scopesEnd:
+    - meta.function-call
 - source: ']'
   scopes:
-    - punctuation.definition.end.bracket.square
+    - punctuation.section.scope.end
   scopesEnd:
-    - meta.bracket.square.access
+    - meta.bracketed
 - source: ;
   scopes:
     - punctuation.terminator.statement
@@ -3141,18 +3442,29 @@
     - keyword.operator.assignment
 - source: '['
   scopesBegin:
-    - meta.bracket.square.access
+    - meta.bracketed
   scopes:
-    - punctuation.definition.begin.bracket.square
-- source: 'labels objectAtIndex:'
+    - punctuation.section.scope.begin
+- source: 'labels '
+- source: objectAtIndex
+  scopesBegin:
+    - meta.function-call
+    - support.function.any-method
+- source: ':'
+  scopes:
+    - punctuation.separator.arguments
+  scopesEnd:
+    - support.function.any-method
 - source: '0'
   scopes:
     - constant.numeric.decimal
+  scopesEnd:
+    - meta.function-call
 - source: ']'
   scopes:
-    - punctuation.definition.end.bracket.square
+    - punctuation.section.scope.end
   scopesEnd:
-    - meta.bracket.square.access
+    - meta.bracketed
 - source: ;
   scopes:
     - punctuation.terminator.statement
@@ -4269,15 +4581,19 @@
     - keyword.operator
 - source: '['
   scopesBegin:
-    - meta.bracket.square.access
+    - meta.bracketed
   scopes:
-    - punctuation.definition.begin.bracket.square
-- source: _labels count
+    - punctuation.section.scope.begin
+- source: '_labels '
+- source: count
+  scopes:
+    - meta.function-call
+    - support.function.any-method
 - source: ']'
   scopes:
-    - punctuation.definition.end.bracket.square
+    - punctuation.section.scope.end
   scopesEnd:
-    - meta.bracket.square.access
+    - meta.bracketed
 - source: ;
   scopes:
     - punctuation.terminator.statement

--- a/source/languages/objc/examples/misc_003.spec.yaml
+++ b/source/languages/objc/examples/misc_003.spec.yaml
@@ -126,43 +126,57 @@
     - punctuation.section.block.begin.bracket.curly
 - source: '['
   scopesBegin:
-    - meta.bracket.square.access
+    - meta.bracketed
   scopes:
-    - punctuation.definition.begin.bracket.square
-- source: _window release
+    - punctuation.section.scope.begin
+- source: '_window '
+- source: release
+  scopes:
+    - meta.function-call
+    - support.function.any-method
 - source: ']'
   scopes:
-    - punctuation.definition.end.bracket.square
+    - punctuation.section.scope.end
   scopesEnd:
-    - meta.bracket.square.access
+    - meta.bracketed
 - source: ;
   scopes:
     - punctuation.terminator.statement
 - source: '['
   scopesBegin:
-    - meta.bracket.square.access
+    - meta.bracketed
   scopes:
-    - punctuation.definition.begin.bracket.square
-- source: _viewController release
+    - punctuation.section.scope.begin
+- source: '_viewController '
+- source: release
+  scopes:
+    - meta.function-call
+    - support.function.any-method
 - source: ']'
   scopes:
-    - punctuation.definition.end.bracket.square
+    - punctuation.section.scope.end
   scopesEnd:
-    - meta.bracket.square.access
+    - meta.bracketed
 - source: ;
   scopes:
     - punctuation.terminator.statement
 - source: '['
   scopesBegin:
-    - meta.bracket.square.access
+    - meta.bracketed
   scopes:
-    - punctuation.definition.begin.bracket.square
-- source: super dealloc
+    - punctuation.section.scope.begin
+- source: super
+  scopes:
+    - variable.language
+- source: dealloc
+  scopes:
+    - meta.function-call
+    - support.function.any-method
 - source: ']'
   scopes:
-    - punctuation.definition.end.bracket.square
+    - punctuation.section.scope.end
   scopesEnd:
-    - meta.bracket.square.access
+    - meta.bracketed
 - source: ;
   scopes:
     - punctuation.terminator.statement
@@ -257,59 +271,82 @@
     - keyword.operator.assignment
 - source: '['
   scopesBegin:
-    - meta.bracket.square.access
+    - meta.bracketed
   scopes:
-    - punctuation.definition.begin.bracket.square
+    - punctuation.section.scope.begin
 - source: '['
   scopesBegin:
-    - meta.bracket.square.access
+    - meta.bracketed
   scopes:
-    - punctuation.definition.begin.bracket.square
+    - punctuation.section.scope.begin
 - source: '['
   scopesBegin:
-    - meta.bracket.square.access
+    - meta.bracketed
   scopes:
-    - punctuation.definition.begin.bracket.square
-- source: UIWindow alloc
+    - punctuation.section.scope.begin
+- source: 'UIWindow '
+- source: alloc
+  scopes:
+    - meta.function-call
+    - support.function.any-method
 - source: ']'
   scopes:
-    - punctuation.definition.end.bracket.square
+    - punctuation.section.scope.end
   scopesEnd:
-    - meta.bracket.square.access
-- source: ' initWithFrame:'
+    - meta.bracketed
+- source: initWithFrame
+  scopesBegin:
+    - meta.function-call
+    - support.function.any-method
+- source: ':'
+  scopes:
+    - punctuation.separator.arguments
+  scopesEnd:
+    - support.function.any-method
 - source: '['
   scopesBegin:
-    - meta.bracket.square.access
+    - meta.bracketed
   scopes:
-    - punctuation.definition.begin.bracket.square
+    - punctuation.section.scope.begin
 - source: '['
   scopesBegin:
-    - meta.bracket.square.access
+    - meta.bracketed
   scopes:
-    - punctuation.definition.begin.bracket.square
-- source: UIScreen mainScreen
+    - punctuation.section.scope.begin
+- source: 'UIScreen '
+- source: mainScreen
+  scopes:
+    - meta.function-call
+    - support.function.any-method
 - source: ']'
   scopes:
-    - punctuation.definition.end.bracket.square
+    - punctuation.section.scope.end
   scopesEnd:
-    - meta.bracket.square.access
-- source: ' bounds'
+    - meta.bracketed
+- source: bounds
+  scopes:
+    - meta.function-call
+    - support.function.any-method
 - source: ']'
   scopes:
-    - punctuation.definition.end.bracket.square
+    - punctuation.section.scope.end
   scopesEnd:
-    - meta.bracket.square.access
+    - meta.function-call
+    - meta.bracketed
 - source: ']'
   scopes:
-    - punctuation.definition.end.bracket.square
+    - punctuation.section.scope.end
   scopesEnd:
-    - meta.bracket.square.access
-- source: ' autorelease'
+    - meta.bracketed
+- source: autorelease
+  scopes:
+    - meta.function-call
+    - support.function.any-method
 - source: ']'
   scopes:
-    - punctuation.definition.end.bracket.square
+    - punctuation.section.scope.end
   scopesEnd:
-    - meta.bracket.square.access
+    - meta.bracketed
 - source: ;
   scopes:
     - punctuation.terminator.statement
@@ -335,26 +372,38 @@
     - keyword.operator.assignment
 - source: '['
   scopesBegin:
-    - meta.bracket.square.access
+    - meta.bracketed
   scopes:
-    - punctuation.definition.begin.bracket.square
+    - punctuation.section.scope.begin
 - source: '['
   scopesBegin:
-    - meta.bracket.square.access
+    - meta.bracketed
   scopes:
-    - punctuation.definition.begin.bracket.square
+    - punctuation.section.scope.begin
 - source: '['
   scopesBegin:
-    - meta.bracket.square.access
+    - meta.bracketed
   scopes:
-    - punctuation.definition.begin.bracket.square
-- source: ViewController alloc
+    - punctuation.section.scope.begin
+- source: 'ViewController '
+- source: alloc
+  scopes:
+    - meta.function-call
+    - support.function.any-method
 - source: ']'
   scopes:
-    - punctuation.definition.end.bracket.square
+    - punctuation.section.scope.end
   scopesEnd:
-    - meta.bracket.square.access
-- source: ' initWithNibName:'
+    - meta.bracketed
+- source: initWithNibName
+  scopesBegin:
+    - meta.function-call
+    - support.function.any-method
+- source: ':'
+  scopes:
+    - punctuation.separator.arguments
+  scopesEnd:
+    - support.function.any-method
 - source: '@"'
   scopesBegin:
     - string.quoted.double
@@ -366,21 +415,33 @@
     - punctuation.definition.string.end
   scopesEnd:
     - string.quoted.double
-- source: ' bundle:'
+- source: bundle
+  scopesBegin:
+    - support.function.any-method.name-of-parameter
+- source: ':'
+  scopes:
+    - punctuation.separator.arguments
+  scopesEnd:
+    - support.function.any-method.name-of-parameter
 - source: nil
   scopes:
     - constant.language
+  scopesEnd:
+    - meta.function-call
 - source: ']'
   scopes:
-    - punctuation.definition.end.bracket.square
+    - punctuation.section.scope.end
   scopesEnd:
-    - meta.bracket.square.access
-- source: ' autorelease'
+    - meta.bracketed
+- source: autorelease
+  scopes:
+    - meta.function-call
+    - support.function.any-method
 - source: ']'
   scopes:
-    - punctuation.definition.end.bracket.square
+    - punctuation.section.scope.end
   scopesEnd:
-    - meta.bracket.square.access
+    - meta.bracketed
 - source: ;
   scopes:
     - punctuation.terminator.statement
@@ -394,35 +455,44 @@
     - keyword.operator.assignment
 - source: '['
   scopesBegin:
-    - meta.bracket.square.access
+    - meta.bracketed
   scopes:
-    - punctuation.definition.begin.bracket.square
+    - punctuation.section.scope.begin
 - source: '['
   scopesBegin:
-    - meta.bracket.square.access
+    - meta.bracketed
   scopes:
-    - punctuation.definition.begin.bracket.square
-- source: SKNavigationController alloc
+    - punctuation.section.scope.begin
+- source: 'SKNavigationController '
+- source: alloc
+  scopes:
+    - meta.function-call
+    - support.function.any-method
 - source: ']'
   scopes:
-    - punctuation.definition.end.bracket.square
+    - punctuation.section.scope.end
   scopesEnd:
-    - meta.bracket.square.access
-- source: ' initWithRootViewController:'
+    - meta.bracketed
+- source: initWithRootViewController
+  scopesBegin:
+    - meta.function-call
+    - support.function.any-method
+- source: ':'
+  scopes:
+    - punctuation.separator.arguments
+  scopesEnd:
+    - support.function.any-method
 - source: self
   scopes:
-    - variable.other.object.access
-- source: .
-  scopes:
-    - punctuation.separator.dot-access
-- source: viewController
-  scopes:
-    - variable.other.member
+    - variable.language
+- source: .viewController
+  scopesEnd:
+    - meta.function-call
 - source: ']'
   scopes:
-    - punctuation.definition.end.bracket.square
+    - punctuation.section.scope.end
   scopesEnd:
-    - meta.bracket.square.access
+    - meta.bracketed
 - source: ;
   scopes:
     - punctuation.terminator.statement
@@ -450,38 +520,40 @@
     - punctuation.terminator.statement
 - source: '['
   scopesBegin:
-    - meta.bracket.square.access
+    - meta.bracketed
   scopes:
-    - punctuation.definition.begin.bracket.square
-- source: nav release
+    - punctuation.section.scope.begin
+- source: 'nav '
+- source: release
+  scopes:
+    - meta.function-call
+    - support.function.any-method
 - source: ']'
   scopes:
-    - punctuation.definition.end.bracket.square
+    - punctuation.section.scope.end
   scopesEnd:
-    - meta.bracket.square.access
+    - meta.bracketed
 - source: ;
   scopes:
     - punctuation.terminator.statement
 - source: '['
   scopesBegin:
-    - meta.bracket.square.access
+    - meta.bracketed
   scopes:
-    - punctuation.definition.begin.bracket.square
+    - punctuation.section.scope.begin
 - source: self
   scopes:
-    - variable.other.object.access
-- source: .
+    - variable.language
+- source: '.window '
+- source: makeKeyAndVisible
   scopes:
-    - punctuation.separator.dot-access
-- source: window
-  scopes:
-    - variable.other.member
-- source: ' makeKeyAndVisible'
+    - meta.function-call
+    - support.function.any-method
 - source: ']'
   scopes:
-    - punctuation.definition.end.bracket.square
+    - punctuation.section.scope.end
   scopesEnd:
-    - meta.bracket.square.access
+    - meta.bracketed
 - source: ;
   scopes:
     - punctuation.terminator.statement

--- a/source/languages/objc/examples/misc_004.spec.yaml
+++ b/source/languages/objc/examples/misc_004.spec.yaml
@@ -121,15 +121,21 @@
     - punctuation.section.block.begin.bracket.curly
 - source: '['
   scopesBegin:
-    - meta.bracket.square.access
+    - meta.bracketed
   scopes:
-    - punctuation.definition.begin.bracket.square
-- source: super viewDidLoad
+    - punctuation.section.scope.begin
+- source: super
+  scopes:
+    - variable.language
+- source: viewDidLoad
+  scopes:
+    - meta.function-call
+    - support.function.any-method
 - source: ']'
   scopes:
-    - punctuation.definition.end.bracket.square
+    - punctuation.section.scope.end
   scopesEnd:
-    - meta.bracket.square.access
+    - meta.bracketed
 - source: ;
   scopes:
     - punctuation.terminator.statement
@@ -153,19 +159,28 @@
     - keyword.operator.assignment
 - source: '['
   scopesBegin:
-    - meta.bracket.square.access
+    - meta.bracketed
   scopes:
-    - punctuation.definition.begin.bracket.square
-- source: 'UIColor colorWithRed:'
+    - punctuation.section.scope.begin
+- source: 'UIColor '
+- source: colorWithRed
+  scopesBegin:
+    - meta.function-call
+    - support.function.any-method
+- source: ':'
+  scopes:
+    - punctuation.separator.arguments
+  scopesEnd:
+    - support.function.any-method
 - source: arc4random
+  scopesBegin:
+    - meta.function-call
   scopes:
-    - entity.name.function
+    - support.function.any-method
 - source: (
-  scopes:
-    - punctuation.section.arguments.begin.bracket.round
+  scopesEnd:
+    - meta.function-call
 - source: )
-  scopes:
-    - punctuation.section.arguments.end.bracket.round
 - source: '%'
   scopes:
     - keyword.operator
@@ -184,16 +199,23 @@
 - source: '0'
   scopes:
     - constant.numeric.decimal
-- source: ' green:'
+- source: green
+  scopesBegin:
+    - support.function.any-method.name-of-parameter
+- source: ':'
+  scopes:
+    - punctuation.separator.arguments
+  scopesEnd:
+    - support.function.any-method.name-of-parameter
 - source: arc4random
+  scopesBegin:
+    - meta.function-call
   scopes:
-    - entity.name.function
+    - support.function.any-method
 - source: (
-  scopes:
-    - punctuation.section.arguments.begin.bracket.round
+  scopesEnd:
+    - meta.function-call
 - source: )
-  scopes:
-    - punctuation.section.arguments.end.bracket.round
 - source: '%'
   scopes:
     - keyword.operator
@@ -212,16 +234,23 @@
 - source: '0'
   scopes:
     - constant.numeric.decimal
-- source: ' blue:'
+- source: blue
+  scopesBegin:
+    - support.function.any-method.name-of-parameter
+- source: ':'
+  scopes:
+    - punctuation.separator.arguments
+  scopesEnd:
+    - support.function.any-method.name-of-parameter
 - source: arc4random
+  scopesBegin:
+    - meta.function-call
   scopes:
-    - entity.name.function
+    - support.function.any-method
 - source: (
-  scopes:
-    - punctuation.section.arguments.begin.bracket.round
+  scopesEnd:
+    - meta.function-call
 - source: )
-  scopes:
-    - punctuation.section.arguments.end.bracket.round
 - source: '%'
   scopes:
     - keyword.operator
@@ -240,15 +269,24 @@
 - source: '0'
   scopes:
     - constant.numeric.decimal
-- source: ' alpha:'
+- source: alpha
+  scopesBegin:
+    - support.function.any-method.name-of-parameter
+- source: ':'
+  scopes:
+    - punctuation.separator.arguments
+  scopesEnd:
+    - support.function.any-method.name-of-parameter
 - source: '1'
   scopes:
     - constant.numeric.decimal
+  scopesEnd:
+    - meta.function-call
 - source: ']'
   scopes:
-    - punctuation.definition.end.bracket.square
+    - punctuation.section.scope.end
   scopesEnd:
-    - meta.bracket.square.access
+    - meta.bracketed
 - source: ;
   scopes:
     - punctuation.terminator.statement
@@ -375,13 +413,21 @@
     - keyword.operator.assignment
 - source: '['
   scopesBegin:
-    - meta.bracket.square.access
+    - meta.bracketed
   scopes:
-    - punctuation.definition.begin.bracket.square
+    - punctuation.section.scope.begin
 - source: NSString
   scopes:
     - support.class.cocoa
-- source: ' stringWithFormat:'
+- source: stringWithFormat
+  scopesBegin:
+    - meta.function-call
+    - support.function.any-method
+- source: ':'
+  scopes:
+    - punctuation.separator.arguments
+  scopesEnd:
+    - support.function.any-method
 - source: '@"'
   scopesBegin:
     - string.quoted.double
@@ -400,35 +446,28 @@
     - punctuation.separator.delimiter
 - source: '['
   scopesBegin:
-    - meta.bracket.square.access
+    - meta.bracketed
   scopes:
-    - punctuation.definition.begin.bracket.square
+    - punctuation.section.scope.begin
 - source: self
   scopes:
-    - variable.other.object.access
-- source: .
+    - variable.language
+- source: '.navigationController.viewControllers '
+- source: count
   scopes:
-    - punctuation.separator.dot-access
-- source: navigationController
-  scopes:
-    - variable.other.object.access
-- source: .
-  scopes:
-    - punctuation.separator.dot-access
-- source: viewControllers
-  scopes:
-    - variable.other.member
-- source: ' count'
+    - meta.function-call
+    - support.function.any-method
 - source: ']'
   scopes:
-    - punctuation.definition.end.bracket.square
+    - punctuation.section.scope.end
   scopesEnd:
-    - meta.bracket.square.access
+    - meta.function-call
+    - meta.bracketed
 - source: ']'
   scopes:
-    - punctuation.definition.end.bracket.square
+    - punctuation.section.scope.end
   scopesEnd:
-    - meta.bracket.square.access
+    - meta.bracketed
 - source: ;
   scopes:
     - punctuation.terminator.statement
@@ -442,30 +481,22 @@
     - punctuation.section.parens.begin.bracket.round
 - source: '['
   scopesBegin:
-    - meta.bracket.square.access
+    - meta.bracketed
   scopes:
-    - punctuation.definition.begin.bracket.square
+    - punctuation.section.scope.begin
 - source: self
   scopes:
-    - variable.other.object.access
-- source: .
+    - variable.language
+- source: '.navigationController.viewControllers '
+- source: count
   scopes:
-    - punctuation.separator.dot-access
-- source: navigationController
-  scopes:
-    - variable.other.object.access
-- source: .
-  scopes:
-    - punctuation.separator.dot-access
-- source: viewControllers
-  scopes:
-    - variable.other.member
-- source: ' count'
+    - meta.function-call
+    - support.function.any-method
 - source: ']'
   scopes:
-    - punctuation.definition.end.bracket.square
+    - punctuation.section.scope.end
   scopesEnd:
-    - meta.bracket.square.access
+    - meta.bracketed
 - source: '%'
   scopes:
     - keyword.operator
@@ -500,13 +531,21 @@
     - keyword.operator.assignment
 - source: '['
   scopesBegin:
-    - meta.bracket.square.access
+    - meta.bracketed
   scopes:
-    - punctuation.definition.begin.bracket.square
+    - punctuation.section.scope.begin
 - source: NSString
   scopes:
     - support.class.cocoa
-- source: ' stringWithFormat:'
+- source: stringWithFormat
+  scopesBegin:
+    - meta.function-call
+    - support.function.any-method
+- source: ':'
+  scopes:
+    - punctuation.separator.arguments
+  scopesEnd:
+    - support.function.any-method
 - source: '@"'
   scopesBegin:
     - string.quoted.double
@@ -524,20 +563,14 @@
 - source: ','
   scopes:
     - punctuation.separator.delimiter
-- source: lbl
-  scopes:
-    - variable.other.object.access
-- source: .
-  scopes:
-    - punctuation.separator.dot-access
-- source: text
-  scopes:
-    - variable.other.member
+- source: lbl.text
+  scopesEnd:
+    - meta.function-call
 - source: ']'
   scopes:
-    - punctuation.definition.end.bracket.square
+    - punctuation.section.scope.end
   scopesEnd:
-    - meta.bracket.square.access
+    - meta.bracketed
 - source: ;
   scopes:
     - punctuation.terminator.statement
@@ -603,63 +636,87 @@
     - keyword.operator.assignment
 - source: '['
   scopesBegin:
-    - meta.bracket.square.access
+    - meta.bracketed
   scopes:
-    - punctuation.definition.begin.bracket.square
+    - punctuation.section.scope.begin
 - source: '['
   scopesBegin:
-    - meta.bracket.square.access
+    - meta.bracketed
   scopes:
-    - punctuation.definition.begin.bracket.square
+    - punctuation.section.scope.begin
 - source: '['
   scopesBegin:
-    - meta.bracket.square.access
+    - meta.bracketed
   scopes:
-    - punctuation.definition.begin.bracket.square
-- source: ViewController alloc
+    - punctuation.section.scope.begin
+- source: 'ViewController '
+- source: alloc
+  scopes:
+    - meta.function-call
+    - support.function.any-method
 - source: ']'
   scopes:
-    - punctuation.definition.end.bracket.square
+    - punctuation.section.scope.end
   scopesEnd:
-    - meta.bracket.square.access
-- source: ' init'
+    - meta.bracketed
+- source: init
+  scopes:
+    - meta.function-call
+    - support.function.any-method
 - source: ']'
   scopes:
-    - punctuation.definition.end.bracket.square
+    - punctuation.section.scope.end
   scopesEnd:
-    - meta.bracket.square.access
-- source: ' autorelease'
+    - meta.bracketed
+- source: autorelease
+  scopes:
+    - meta.function-call
+    - support.function.any-method
 - source: ']'
   scopes:
-    - punctuation.definition.end.bracket.square
+    - punctuation.section.scope.end
   scopesEnd:
-    - meta.bracket.square.access
+    - meta.bracketed
 - source: ;
   scopes:
     - punctuation.terminator.statement
 - source: '['
   scopesBegin:
-    - meta.bracket.square.access
+    - meta.bracketed
   scopes:
-    - punctuation.definition.begin.bracket.square
+    - punctuation.section.scope.begin
 - source: self
   scopes:
-    - variable.other.object.access
-- source: .
+    - variable.language
+- source: '.navigationController '
+- source: pushViewController
+  scopesBegin:
+    - meta.function-call
+    - support.function.any-method
+- source: ':'
   scopes:
-    - punctuation.separator.dot-access
-- source: navigationController
+    - punctuation.separator.arguments
+  scopesEnd:
+    - support.function.any-method
+- source: 'v '
+- source: animated
+  scopesBegin:
+    - support.function.any-method.name-of-parameter
+- source: ':'
   scopes:
-    - variable.other.member
-- source: ' pushViewController:v animated:'
+    - punctuation.separator.arguments
+  scopesEnd:
+    - support.function.any-method.name-of-parameter
 - source: 'YES'
   scopes:
     - constant.language
+  scopesEnd:
+    - meta.function-call
 - source: ']'
   scopes:
-    - punctuation.definition.end.bracket.square
+    - punctuation.section.scope.end
   scopesEnd:
-    - meta.bracket.square.access
+    - meta.bracketed
 - source: ;
   scopes:
     - punctuation.terminator.statement
@@ -695,15 +752,21 @@
     - punctuation.section.block.begin.bracket.curly
 - source: '['
   scopesBegin:
-    - meta.bracket.square.access
+    - meta.bracketed
   scopes:
-    - punctuation.definition.begin.bracket.square
-- source: super didReceiveMemoryWarning
+    - punctuation.section.scope.begin
+- source: super
+  scopes:
+    - variable.language
+- source: didReceiveMemoryWarning
+  scopes:
+    - meta.function-call
+    - support.function.any-method
 - source: ']'
   scopes:
-    - punctuation.definition.end.bracket.square
+    - punctuation.section.scope.end
   scopesEnd:
-    - meta.bracket.square.access
+    - meta.bracketed
 - source: ;
   scopes:
     - punctuation.terminator.statement

--- a/source/languages/objc/original.tmLanguage.json
+++ b/source/languages/objc/original.tmLanguage.json
@@ -285,10 +285,10 @@
       "name": "support.constant.cocoa.objc"
     },
     {
-      "include": "#c_lang"
+      "include": "#bracketed_content"
     },
     {
-      "include": "#bracketed_content"
+      "include": "#c_lang"
     }
   ],
   "repository": {
@@ -321,6 +321,10 @@
           "name": "keyword.other.typedef.objc"
         },
         {
+          "match": "\\bin\\b",
+          "name": "keyword.other.in.objc"
+        },
+        {
           "match": "\\b(const|extern|register|restrict|static|volatile|inline|__block)\\b",
           "name": "storage.modifier.objc"
         },
@@ -348,6 +352,9 @@
         },
         {
           "include": "#strings"
+        },
+        {
+          "include": "#special_variables"
         },
         {
           "begin": "(?x)\n^\\s* ((\\#)\\s*define) \\s+\t# define\n((?<id>[a-zA-Z_$][\\w$]*))\t  # macro name\n(?:\n  (\\()\n\t(\n\t  \\s* \\g<id> \\s*\t\t # first argument\n\t  ((,) \\s* \\g<id> \\s*)*  # additional arguments\n\t  (?:\\.\\.\\.)?\t\t\t# varargs ellipsis?\n\t)\n  (\\))\n)?",
@@ -3150,9 +3157,6 @@
         },
         {
           "include": "#property_directive"
-        },
-        {
-          "include": "#special_variables"
         },
         {
           "include": "#method_super"

--- a/source/languages/objcpp/examples/examples.spec.yaml
+++ b/source/languages/objcpp/examples/examples.spec.yaml
@@ -150,7 +150,10 @@
 - source: '*'
   scopes:
     - keyword.operator
-- source: 'device in '
+- source: 'device '
+- source: in
+  scopes:
+    - keyword.other.in
 - source: session
   scopes:
     - variable.other.object.access

--- a/source/languages/objcpp/examples/misc.spec.yaml
+++ b/source/languages/objcpp/examples/misc.spec.yaml
@@ -174,7 +174,7 @@
     - punctuation.section.block.begin.bracket.curly
 - source: __block
   scopes:
-    - storage.modifier.objc
+    - storage.modifier
 - source: bool
   scopes:
     - storage.type.built-in.primitive

--- a/source/languages/objcpp/original.tmLanguage.json
+++ b/source/languages/objcpp/original.tmLanguage.json
@@ -289,10 +289,10 @@
       "name": "support.constant.cocoa.objcpp"
     },
     {
-      "include": "#c_lang"
+      "include": "#bracketed_content"
     },
     {
-      "include": "#bracketed_content"
+      "include": "#c_lang"
     }
   ],
   "repository": {
@@ -325,6 +325,10 @@
           "name": "keyword.other.typedef.objcpp"
         },
         {
+          "match": "\\bin\\b",
+          "name": "keyword.other.in.objcpp"
+        },
+        {
           "match": "\\b(const|extern|register|restrict|static|volatile|inline|__block)\\b",
           "name": "storage.modifier.objcpp"
         },
@@ -352,6 +356,9 @@
         },
         {
           "include": "#strings"
+        },
+        {
+          "include": "#special_variables"
         },
         {
           "begin": "(?x)\n^\\s* ((\\#)\\s*define) \\s+\t# define\n((?<id>[a-zA-Z_$][\\w$]*))\t  # macro name\n(?:\n  (\\()\n\t(\n\t  \\s* \\g<id> \\s*\t\t # first argument\n\t  ((,) \\s* \\g<id> \\s*)*  # additional arguments\n\t  (?:\\.\\.\\.)?\t\t\t# varargs ellipsis?\n\t)\n  (\\))\n)?",
@@ -6643,9 +6650,6 @@
         },
         {
           "include": "#property_directive"
-        },
-        {
-          "include": "#special_variables"
         },
         {
           "include": "#method_super"

--- a/syntaxes/objc.tmLanguage.json
+++ b/syntaxes/objc.tmLanguage.json
@@ -286,10 +286,10 @@
       "name": "support.constant.cocoa.objc"
     },
     {
-      "include": "#c_lang"
+      "include": "#bracketed_content"
     },
     {
-      "include": "#bracketed_content"
+      "include": "#c_lang"
     }
   ],
   "repository": {
@@ -502,6 +502,10 @@
           "name": "keyword.other.typedef.objc"
         },
         {
+          "match": "\\bin\\b",
+          "name": "keyword.other.in.objc"
+        },
+        {
           "match": "\\b(const|extern|register|restrict|static|volatile|inline|__block)\\b",
           "name": "storage.modifier.objc"
         },
@@ -529,6 +533,9 @@
         },
         {
           "include": "#strings"
+        },
+        {
+          "include": "#special_variables"
         },
         {
           "begin": "(?x)\n^\\s* ((\\#)\\s*define) \\s+\t# define\n((?<id>[a-zA-Z_$][\\w$]*))\t  # macro name\n(?:\n  (\\()\n\t(\n\t  \\s* \\g<id> \\s*\t\t # first argument\n\t  ((,) \\s* \\g<id> \\s*)*  # additional arguments\n\t  (?:\\.\\.\\.)?\t\t\t# varargs ellipsis?\n\t)\n  (\\))\n)?",
@@ -3123,9 +3130,6 @@
         },
         {
           "include": "#property_directive"
-        },
-        {
-          "include": "#special_variables"
         },
         {
           "include": "#method_super"

--- a/syntaxes/objcpp.tmLanguage.json
+++ b/syntaxes/objcpp.tmLanguage.json
@@ -290,10 +290,10 @@
       "name": "support.constant.cocoa.objcpp"
     },
     {
-      "include": "#c_lang"
+      "include": "#bracketed_content"
     },
     {
-      "include": "#bracketed_content"
+      "include": "#c_lang"
     }
   ],
   "repository": {
@@ -506,6 +506,10 @@
           "name": "keyword.other.typedef.objcpp"
         },
         {
+          "match": "\\bin\\b",
+          "name": "keyword.other.in.objcpp"
+        },
+        {
           "match": "\\b(const|extern|register|restrict|static|volatile|inline|__block)\\b",
           "name": "storage.modifier.objcpp"
         },
@@ -533,6 +537,9 @@
         },
         {
           "include": "#strings"
+        },
+        {
+          "include": "#special_variables"
         },
         {
           "begin": "(?x)\n^\\s* ((\\#)\\s*define) \\s+\t# define\n((?<id>[a-zA-Z_$][\\w$]*))\t  # macro name\n(?:\n  (\\()\n\t(\n\t  \\s* \\g<id> \\s*\t\t # first argument\n\t  ((,) \\s* \\g<id> \\s*)*  # additional arguments\n\t  (?:\\.\\.\\.)?\t\t\t# varargs ellipsis?\n\t)\n  (\\))\n)?",
@@ -6616,9 +6623,6 @@
         },
         {
           "include": "#property_directive"
-        },
-        {
-          "include": "#special_variables"
         },
         {
           "include": "#method_super"


### PR DESCRIPTION
- Highlight `in` keyword
- Improve `self/super/_cmd` highlighting, previously
  it would trigger in an @implementation and a few other places
- Improve detection of Objective-C method calls, previously it would
  get mixed up with `meta.bracket.square.access`

Fixes #550 and fixes #538